### PR TITLE
fix: Heading Links in Table

### DIFF
--- a/src/Publisher.ts
+++ b/src/Publisher.ts
@@ -333,11 +333,11 @@ export default class Publisher {
                     const fullLinkedFilePath = getLinkpath(linkedFileName);
                     const linkedFile = this.metadataCache.getFirstLinkpathDest(fullLinkedFilePath, filePath);
                     if (!linkedFile) {
-                        convertedText = convertedText.replace(linkMatch, `[[${linkedFileName}${headerPath}\|${prettyName}]]`);
+                        convertedText = convertedText.replace(linkMatch, `[[${linkedFileName}${headerPath}\\|${prettyName}]]`);
                     }
                     if (linkedFile?.extension === "md") {
                         const extensionlessPath = linkedFile.path.substring(0, linkedFile.path.lastIndexOf('.'));
-                        convertedText = convertedText.replace(linkMatch, `[[${extensionlessPath}${headerPath}\|${prettyName}]]`);
+                        convertedText = convertedText.replace(linkMatch, `[[${extensionlessPath}${headerPath}\\|${prettyName}]]`);
                     }
                 } catch (e) {
                     console.log(e);

--- a/src/Publisher.ts
+++ b/src/Publisher.ts
@@ -333,11 +333,11 @@ export default class Publisher {
                     const fullLinkedFilePath = getLinkpath(linkedFileName);
                     const linkedFile = this.metadataCache.getFirstLinkpathDest(fullLinkedFilePath, filePath);
                     if (!linkedFile) {
-                        convertedText = convertedText.replace(linkMatch, `[[${linkedFileName}${headerPath}|${prettyName}]]`);
+                        convertedText = convertedText.replace(linkMatch, `[[${linkedFileName}${headerPath}\|${prettyName}]]`);
                     }
                     if (linkedFile?.extension === "md") {
                         const extensionlessPath = linkedFile.path.substring(0, linkedFile.path.lastIndexOf('.'));
-                        convertedText = convertedText.replace(linkMatch, `[[${extensionlessPath}${headerPath}|${prettyName}]]`);
+                        convertedText = convertedText.replace(linkMatch, `[[${extensionlessPath}${headerPath}\|${prettyName}]]`);
                     }
                 } catch (e) {
                     console.log(e);


### PR DESCRIPTION
<img width="727" alt="image" src="https://user-images.githubusercontent.com/48207708/196331194-6234f6c7-776a-4fa0-96fa-344d33a4ed01.png">

Heading links do not work in tables. It may be because this replacement
https://github.com/oleeskild/obsidian-digital-garden/blob/9d288f5bab36cf28b9658b16025aadc15fd6638d/src/Publisher.ts#L336

puts a pipe in the link.

So I modified these two replacements, based on the fact that `[[note#heading\|prettyName]]` works fine.
However, I haven't build the project on my end. So feel free to close this pull request if it doesn't work.