### PR TITLE
Note Icon support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ deploy.sh
 
 # mac
 .DS_Store
+yarn.lock

--- a/main.ts
+++ b/main.ts
@@ -22,6 +22,13 @@ const DEFAULT_SETTINGS: DigitalGardenSettings = {
 	noteSettingsIsInitialized: false,
 	siteName: 'Digital Garden',
 	slugifyEnabled: true,
+	// Maturity Related Settings
+	maturityKey: "dg-maturity",
+	defaultMaturity: '1',
+	showMaturityOnTitle: false,
+	showMaturityInFileTree: false,
+	showMaturityOnInternalLink: false,
+
 	defaultNoteSettings: {
 		dgHomeLink: true,
 		dgPassFrontmatter: false,

--- a/main.ts
+++ b/main.ts
@@ -22,12 +22,12 @@ const DEFAULT_SETTINGS: DigitalGardenSettings = {
 	noteSettingsIsInitialized: false,
 	siteName: 'Digital Garden',
 	slugifyEnabled: true,
-	// Maturity Related Settings
-	maturityKey: "dg-maturity",
-	defaultMaturity: '1',
-	showMaturityOnTitle: false,
-	showMaturityInFileTree: false,
-	showMaturityOnInternalLink: false,
+	// Note Icon Related Settings
+	noteIconKey: "dg-note-icon",
+	defaultNoteIcon: '1',
+	showNoteIconOnTitle: false,
+	showNoteIconInFileTree: false,
+	showNoteIconOnInternalLink: false,
 
 	defaultNoteSettings: {
 		dgHomeLink: true,

--- a/main.ts
+++ b/main.ts
@@ -24,7 +24,7 @@ const DEFAULT_SETTINGS: DigitalGardenSettings = {
 	slugifyEnabled: true,
 	// Note Icon Related Settings
 	noteIconKey: "dg-note-icon",
-	defaultNoteIcon: '1',
+	defaultNoteIcon: '',
 	showNoteIconOnTitle: false,
 	showNoteIconInFileTree: false,
 	showNoteIconOnInternalLink: false,

--- a/src/DigitalGardenSettings.ts
+++ b/src/DigitalGardenSettings.ts
@@ -16,11 +16,11 @@ export default interface DigitalGardenSettings {
 
 	slugifyEnabled: boolean;
 
-	maturityKey: string;
-	defaultMaturity: string;
-	showMaturityOnTitle: boolean;
-	showMaturityInFileTree: boolean;
-	showMaturityOnInternalLink: boolean;
+	noteIconKey: string;
+	defaultNoteIcon: string;
+	showNoteIconOnTitle: boolean;
+	showNoteIconInFileTree: boolean;
+	showNoteIconOnInternalLink: boolean;
 
 	defaultNoteSettings: {
 		dgHomeLink: boolean;

--- a/src/DigitalGardenSettings.ts
+++ b/src/DigitalGardenSettings.ts
@@ -16,6 +16,12 @@ export default interface DigitalGardenSettings {
 
 	slugifyEnabled: boolean;
 
+	maturityKey: string;
+	defaultMaturity: string;
+	showMaturityOnTitle: boolean;
+	showMaturityInFileTree: boolean;
+	showMaturityOnInternalLink: boolean;
+
 	defaultNoteSettings: {
 		dgHomeLink: boolean;
 		dgPassFrontmatter: boolean;

--- a/src/DigitalGardenSiteManager.ts
+++ b/src/DigitalGardenSiteManager.ts
@@ -40,10 +40,10 @@ export default class DigitalGardenSiteManager implements IDigitalGardenSiteManag
         }
         envSettings+=`\nSITE_NAME_HEADER=${siteName}`;
 		envSettings += `\nSITE_BASE_URL=${gardenBaseUrl}`;
-		envSettings += `\nMATURITY_DEFAULT=${this.settings.defaultMaturity}`;
-		envSettings += `\nMATURITY_TITLE=${this.settings.showMaturityOnTitle}`;
-		envSettings += `\nMATURITY_FILETREE=${this.settings.showMaturityInFileTree}`;
-		envSettings+=`\nMATURITY_INTERNAL_LINKS=${this.settings.showMaturityOnInternalLink}`;
+		envSettings += `\nNOTE_ICON_DEFAULT=${this.settings.defaultNoteIcon}`;
+		envSettings += `\nNOTE_ICON_TITLE=${this.settings.showNoteIconOnTitle}`;
+		envSettings += `\nNOTE_ICON_FILETREE=${this.settings.showNoteIconInFileTree}`;
+		envSettings+=`\nNOTE_ICON_INTERNAL_LINKS=${this.settings.showNoteIconOnInternalLink}`;
 
         const defaultNoteSettings = {...this.settings.defaultNoteSettings};
         for(const key of Object.keys(defaultNoteSettings)) {

--- a/src/DigitalGardenSiteManager.ts
+++ b/src/DigitalGardenSiteManager.ts
@@ -39,7 +39,11 @@ export default class DigitalGardenSiteManager implements IDigitalGardenSiteManag
             envSettings = `THEME=${theme.cssUrl}\nBASE_THEME=${baseTheme}`;
         }
         envSettings+=`\nSITE_NAME_HEADER=${siteName}`;
-        envSettings+=`\nSITE_BASE_URL=${gardenBaseUrl}`;
+		envSettings += `\nSITE_BASE_URL=${gardenBaseUrl}`;
+		envSettings += `\nMATURITY_DEFAULT=${this.settings.defaultMaturity}`;
+		envSettings += `\nMATURITY_TITLE=${this.settings.showMaturityOnTitle}`;
+		envSettings += `\nMATURITY_FILETREE=${this.settings.showMaturityInFileTree}`;
+		envSettings+=`\nMATURITY_INTERNAL_LINKS=${this.settings.showMaturityOnInternalLink}`;
 
         const defaultNoteSettings = {...this.settings.defaultNoteSettings};
         for(const key of Object.keys(defaultNoteSettings)) {

--- a/src/Publisher.ts
+++ b/src/Publisher.ts
@@ -309,7 +309,8 @@ export default class Publisher {
 		publishedFrontMatter = this.addDefaultPassThrough(fileFrontMatter, publishedFrontMatter);
         publishedFrontMatter = this.addPageTags(fileFrontMatter, publishedFrontMatter);
         publishedFrontMatter = this.addFrontMatterSettings(fileFrontMatter, publishedFrontMatter);
-
+		publishedFrontMatter = this.addMaturityFrontMatter(fileFrontMatter, publishedFrontMatter);
+		
         const fullFrontMatter = publishedFrontMatter?.dgPassFrontmatter ? { ...fileFrontMatter, ...publishedFrontMatter } : publishedFrontMatter;
         const frontMatterString = JSON.stringify(fullFrontMatter);
 
@@ -362,7 +363,21 @@ export default class Publisher {
             }
         }
         return publishedFrontMatter;
-    }
+	}
+	
+	addMaturityFrontMatter(baseFrontMatter: any, newFrontMatter: any) {
+		if (!baseFrontMatter) {
+            baseFrontMatter = {};
+		}
+		const publishedFrontMatter = { ...newFrontMatter };
+		const maturityKey = this.settings.maturityKey;
+		if (baseFrontMatter[maturityKey] !== undefined) {
+			publishedFrontMatter['maturity'] = baseFrontMatter[maturityKey];
+		} else {
+			publishedFrontMatter['maturity'] = this.settings.defaultMaturity;
+		}
+		return publishedFrontMatter;
+	}
 
     addFrontMatterSettings(baseFrontMatter: {}, newFrontMatter: {}) {
         if (!baseFrontMatter) {

--- a/src/Publisher.ts
+++ b/src/Publisher.ts
@@ -309,7 +309,7 @@ export default class Publisher {
 		publishedFrontMatter = this.addDefaultPassThrough(fileFrontMatter, publishedFrontMatter);
         publishedFrontMatter = this.addPageTags(fileFrontMatter, publishedFrontMatter);
         publishedFrontMatter = this.addFrontMatterSettings(fileFrontMatter, publishedFrontMatter);
-		publishedFrontMatter = this.addMaturityFrontMatter(fileFrontMatter, publishedFrontMatter);
+		publishedFrontMatter = this.addNoteIconFrontMatter(fileFrontMatter, publishedFrontMatter);
 		
         const fullFrontMatter = publishedFrontMatter?.dgPassFrontmatter ? { ...fileFrontMatter, ...publishedFrontMatter } : publishedFrontMatter;
         const frontMatterString = JSON.stringify(fullFrontMatter);
@@ -365,16 +365,16 @@ export default class Publisher {
         return publishedFrontMatter;
 	}
 	
-	addMaturityFrontMatter(baseFrontMatter: any, newFrontMatter: any) {
+	addNoteIconFrontMatter(baseFrontMatter: any, newFrontMatter: any) {
 		if (!baseFrontMatter) {
             baseFrontMatter = {};
 		}
 		const publishedFrontMatter = { ...newFrontMatter };
-		const maturityKey = this.settings.maturityKey;
-		if (baseFrontMatter[maturityKey] !== undefined) {
-			publishedFrontMatter['maturity'] = baseFrontMatter[maturityKey];
+		const noteIconKey = this.settings.noteIconKey;
+		if (baseFrontMatter[noteIconKey] !== undefined) {
+			publishedFrontMatter['noteIcon'] = baseFrontMatter[noteIconKey];
 		} else {
-			publishedFrontMatter['maturity'] = this.settings.defaultMaturity;
+			publishedFrontMatter['noteIcon'] = this.settings.defaultNoteIcon;
 		}
 		return publishedFrontMatter;
 	}

--- a/src/SettingView.ts
+++ b/src/SettingView.ts
@@ -238,6 +238,60 @@ export default class SettingView {
                 });
                 new SvgFileSuggest(this.app, tc.inputEl)
             })
+		
+		themeModal.contentEl.createEl('h2', { text: "Maturity Settings" });
+
+		new Setting(themeModal.contentEl)
+			.setName('Maturity Frontmatter Key')
+			.setDesc('Key to get the maturity value from the frontmatter')
+			.addText(text =>
+				text.setValue(this.settings.maturityKey)
+					.onChange(async (value) => {
+						this.settings.maturityKey = value;
+						await this.saveSettings();
+					})
+		);
+
+		new Setting(themeModal.contentEl)
+			.setName('Default Maturity Value')
+			.setDesc('The default value for maturity if not specified')
+			.addText(text => {
+				text.setValue(this.settings.defaultMaturity)
+					.onChange(async (value) => {
+						this.settings.defaultMaturity = value;
+						await this.saveSettings();
+					})
+				});
+
+		new Setting(themeModal.contentEl)
+			.setName("Show Maturity on Title")
+			.addToggle(t => {
+				t.setValue(this.settings.showMaturityOnTitle)
+					.onChange(async (value) => {
+						this.settings.showMaturityOnTitle = value;
+						await this.saveSettings();
+					})
+			});
+		
+		new Setting(themeModal.contentEl)
+			.setName("Show Maturity in FileTree")
+			.addToggle(t => {
+				t.setValue(this.settings.showMaturityInFileTree)
+					.onChange(async (value) => {
+						this.settings.showMaturityInFileTree = value;
+						await this.saveSettings();
+					})
+			});
+		
+		new Setting(themeModal.contentEl)
+			.setName("Show Maturity on Internal Links")
+			.addToggle(t => {
+				t.setValue(this.settings.showMaturityOnInternalLink)
+					.onChange(async (value) => {
+						this.settings.showMaturityOnInternalLink = value;
+						await this.saveSettings();
+					})
+			});
 
 
         new Setting(themeModal.contentEl)

--- a/src/SettingView.ts
+++ b/src/SettingView.ts
@@ -239,56 +239,56 @@ export default class SettingView {
                 new SvgFileSuggest(this.app, tc.inputEl)
             })
 		
-		themeModal.contentEl.createEl('h2', { text: "Maturity Settings" });
+		themeModal.contentEl.createEl('h2', { text: "Note icons Settings" });
 
 		new Setting(themeModal.contentEl)
-			.setName('Maturity Frontmatter Key')
-			.setDesc('Key to get the maturity value from the frontmatter')
+			.setName('Note icon Frontmatter Key')
+			.setDesc('Key to get the note icon value from the frontmatter')
 			.addText(text =>
-				text.setValue(this.settings.maturityKey)
+				text.setValue(this.settings.noteIconKey)
 					.onChange(async (value) => {
-						this.settings.maturityKey = value;
+						this.settings.noteIconKey = value;
 						await this.saveSettings();
 					})
 		);
 
 		new Setting(themeModal.contentEl)
-			.setName('Default Maturity Value')
-			.setDesc('The default value for maturity if not specified')
+			.setName('Default note icon Value')
+			.setDesc('The default value for note icon if not specified')
 			.addText(text => {
-				text.setValue(this.settings.defaultMaturity)
+				text.setValue(this.settings.defaultNoteIcon)
 					.onChange(async (value) => {
-						this.settings.defaultMaturity = value;
+						this.settings.defaultNoteIcon = value;
 						await this.saveSettings();
 					})
 				});
 
 		new Setting(themeModal.contentEl)
-			.setName("Show Maturity on Title")
+			.setName("Show note icon on Title")
 			.addToggle(t => {
-				t.setValue(this.settings.showMaturityOnTitle)
+				t.setValue(this.settings.showNoteIconOnTitle)
 					.onChange(async (value) => {
-						this.settings.showMaturityOnTitle = value;
+						this.settings.showNoteIconOnTitle = value;
 						await this.saveSettings();
 					})
 			});
 		
 		new Setting(themeModal.contentEl)
-			.setName("Show Maturity in FileTree")
+			.setName("Show note icon in FileTree")
 			.addToggle(t => {
-				t.setValue(this.settings.showMaturityInFileTree)
+				t.setValue(this.settings.showNoteIconInFileTree)
 					.onChange(async (value) => {
-						this.settings.showMaturityInFileTree = value;
+						this.settings.showNoteIconInFileTree = value;
 						await this.saveSettings();
 					})
 			});
 		
 		new Setting(themeModal.contentEl)
-			.setName("Show Maturity on Internal Links")
+			.setName("Show note icon on Internal Links")
 			.addToggle(t => {
-				t.setValue(this.settings.showMaturityOnInternalLink)
+				t.setValue(this.settings.showNoteIconOnInternalLink)
 					.onChange(async (value) => {
-						this.settings.showMaturityOnInternalLink = value;
+						this.settings.showNoteIconOnInternalLink = value;
 						await this.saveSettings();
 					})
 			});


### PR DESCRIPTION
This PR adds the following items in the appearance settings:

1. Key for note icons (To set which key from frontmatter should be used for note icons, defaults to `dg-note-icon`)
2. Default note icon value (To be used for fallback)
3. Show in Filetree
4. Show in Internal Links
5. Show in Title

It transports values from 2-5 to the sites `.env` file and processes note accordingly to add maturity values.