### PR TITLE
feat: Support for GDPR compliant google font usage

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -28,6 +28,7 @@ const DEFAULT_SETTINGS: DigitalGardenSettings = {
 	showNoteIconOnTitle: false,
 	showNoteIconInFileTree: false,
 	showNoteIconOnInternalLink: false,
+	allowGoogleFontsFromCDN: true,
 
 	defaultNoteSettings: {
 		dgHomeLink: true,

--- a/main.ts
+++ b/main.ts
@@ -28,7 +28,7 @@ const DEFAULT_SETTINGS: DigitalGardenSettings = {
 	showNoteIconOnTitle: false,
 	showNoteIconInFileTree: false,
 	showNoteIconOnInternalLink: false,
-	allowGoogleFontsFromCDN: true,
+	allowGoogleFontsFromCDN: false,
 
 	defaultNoteSettings: {
 		dgHomeLink: true,

--- a/src/DigitalGardenSettings.ts
+++ b/src/DigitalGardenSettings.ts
@@ -22,6 +22,8 @@ export default interface DigitalGardenSettings {
 	showNoteIconInFileTree: boolean;
 	showNoteIconOnInternalLink: boolean;
 
+	allowGoogleFontsFromCDN: boolean;
+
 	defaultNoteSettings: {
 		dgHomeLink: boolean;
 		dgPassFrontmatter: boolean;

--- a/src/DigitalGardenSiteManager.ts
+++ b/src/DigitalGardenSiteManager.ts
@@ -40,6 +40,7 @@ export default class DigitalGardenSiteManager implements IDigitalGardenSiteManag
         }
         envSettings+=`\nSITE_NAME_HEADER=${siteName}`;
 		envSettings += `\nSITE_BASE_URL=${gardenBaseUrl}`;
+		envSettings += `\nALLOW_GOOGLE_FONT=${this.settings.allowGoogleFontsFromCDN}`;
 		envSettings += `\nNOTE_ICON_DEFAULT=${this.settings.defaultNoteIcon}`;
 		envSettings += `\nNOTE_ICON_TITLE=${this.settings.showNoteIconOnTitle}`;
 		envSettings += `\nNOTE_ICON_FILETREE=${this.settings.showNoteIconInFileTree}`;

--- a/src/SettingView.ts
+++ b/src/SettingView.ts
@@ -237,7 +237,18 @@ export default class SettingView {
                     await this.saveSettings();
                 });
                 new SvgFileSuggest(this.app, tc.inputEl)
-            })
+			})
+		
+		new Setting(themeModal.contentEl)
+			.setName("Allow google font from CDN")
+			.setDesc("Turning this off will serve Roboto and (other google fonts shipped with digital garden) from local server instead of CDN, making it GDPR compliant.")
+			.addToggle(t => {
+				t.setValue(this.settings.allowGoogleFontsFromCDN)
+					.onChange(async (value) => {
+						this.settings.allowGoogleFontsFromCDN = value;
+						await this.saveSettings();
+					})
+			});
 		
 		themeModal.contentEl.createEl('h2', { text: "Note icons Settings" });
 


### PR DESCRIPTION
This PR adds a toggle to choose whether the default google font shipped with the template (namely Roboto) will be served from a locally downloaded version or Google's CDN. This will allow it to be GDPR compliant.

https://github.com/oleeskild/obsidian-digital-garden/discussions/196