### PR TITLE
Add content classes to notes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -39,7 +39,7 @@ const DEFAULT_SETTINGS: DigitalGardenSettings = {
 	styleSettingsCss: '',
 	pathRewriteRules: '',
 
-	bodyClassesKey: 'dg-body-classes',
+	contentClassesKey: 'dg-body-classes',
 
 	defaultNoteSettings: {
 		dgHomeLink: true,

--- a/main.ts
+++ b/main.ts
@@ -39,6 +39,8 @@ const DEFAULT_SETTINGS: DigitalGardenSettings = {
 	styleSettingsCss: '',
 	pathRewriteRules: '',
 
+	bodyClassesKey: 'dg-body-classes',
+
 	defaultNoteSettings: {
 		dgHomeLink: true,
 		dgPassFrontmatter: false,

--- a/main.ts
+++ b/main.ts
@@ -39,7 +39,7 @@ const DEFAULT_SETTINGS: DigitalGardenSettings = {
 	styleSettingsCss: '',
 	pathRewriteRules: '',
 
-	contentClassesKey: 'dg-body-classes',
+	contentClassesKey: 'dg-content-classes',
 
 	defaultNoteSettings: {
 		dgHomeLink: true,

--- a/src/DigitalGardenSettings.ts
+++ b/src/DigitalGardenSettings.ts
@@ -32,6 +32,7 @@ export default interface DigitalGardenSettings {
 
 	styleSettingsCss: string;
 	pathRewriteRules: string;
+	bodyClassesKey: string;
 
 	defaultNoteSettings: {
 		dgHomeLink: boolean;

--- a/src/DigitalGardenSettings.ts
+++ b/src/DigitalGardenSettings.ts
@@ -32,7 +32,7 @@ export default interface DigitalGardenSettings {
 
 	styleSettingsCss: string;
 	pathRewriteRules: string;
-	bodyClassesKey: string;
+	contentClassesKey: string;
 
 	defaultNoteSettings: {
 		dgHomeLink: boolean;

--- a/src/Publisher.ts
+++ b/src/Publisher.ts
@@ -463,15 +463,15 @@ export default class Publisher {
 		const publishedFrontMatter = { ...newFrontMatter };
 		
 		if (baseFrontMatter) {
-			const bodyClassesKey = this.settings.bodyClassesKey;
-			if (bodyClassesKey && baseFrontMatter[bodyClassesKey]) {
-				console.log(baseFrontMatter[bodyClassesKey]);
-				if (typeof baseFrontMatter[bodyClassesKey] == "string") {
-					publishedFrontMatter['bodyClasses'] = baseFrontMatter[bodyClassesKey];
-				} else if (Array.isArray(baseFrontMatter[bodyClassesKey])) { 
-					publishedFrontMatter['bodyClasses'] = baseFrontMatter[bodyClassesKey].join(" ");
+			const contentClassesKey = this.settings.contentClassesKey;
+			if (contentClassesKey && baseFrontMatter[contentClassesKey]) {
+				console.log(baseFrontMatter[contentClassesKey]);
+				if (typeof baseFrontMatter[contentClassesKey] == "string") {
+					publishedFrontMatter['contentClasses'] = baseFrontMatter[contentClassesKey];
+				} else if (Array.isArray(baseFrontMatter[contentClassesKey])) { 
+					publishedFrontMatter['contentClasses'] = baseFrontMatter[contentClassesKey].join(" ");
 				} else {
-					publishedFrontMatter['bodyClasses'] = "";
+					publishedFrontMatter['contentClasses'] = "";
 				}
 			}
 		}

--- a/src/Publisher.ts
+++ b/src/Publisher.ts
@@ -386,7 +386,8 @@ export default class Publisher {
 
         publishedFrontMatter = this.addPermalink(fileFrontMatter, publishedFrontMatter, file.path);
 		publishedFrontMatter = this.addDefaultPassThrough(fileFrontMatter, publishedFrontMatter);
-        publishedFrontMatter = this.addPageTags(fileFrontMatter, publishedFrontMatter);
+		publishedFrontMatter = this.addBodyClasses(fileFrontMatter, publishedFrontMatter);
+		publishedFrontMatter = this.addPageTags(fileFrontMatter, publishedFrontMatter);
         publishedFrontMatter = this.addFrontMatterSettings(fileFrontMatter, publishedFrontMatter);
         publishedFrontMatter = this.addNoteIconFrontMatter(fileFrontMatter, publishedFrontMatter);
         publishedFrontMatter = this.addTimestampsFrontmatter(fileFrontMatter, publishedFrontMatter, file);
@@ -456,6 +457,26 @@ export default class Publisher {
             }
         }
         return publishedFrontMatter;
+	}
+
+	addBodyClasses(baseFrontMatter: any, newFrontMatter: any) {
+		const publishedFrontMatter = { ...newFrontMatter };
+		
+		if (baseFrontMatter) {
+			const bodyClassesKey = this.settings.bodyClassesKey;
+			if (bodyClassesKey && baseFrontMatter[bodyClassesKey]) {
+				console.log(baseFrontMatter[bodyClassesKey]);
+				if (typeof baseFrontMatter[bodyClassesKey] == "string") {
+					publishedFrontMatter['bodyClasses'] = baseFrontMatter[bodyClassesKey];
+				} else if (Array.isArray(baseFrontMatter[bodyClassesKey])) { 
+					publishedFrontMatter['bodyClasses'] = baseFrontMatter[bodyClassesKey].join(" ");
+				} else {
+					publishedFrontMatter['bodyClasses'] = "";
+				}
+			}
+		}
+
+		return publishedFrontMatter;
 	}
 
 	addTimestampsFrontmatter(baseFrontMatter: any, newFrontMatter: any, file: TFile) {

--- a/src/Publisher.ts
+++ b/src/Publisher.ts
@@ -386,7 +386,7 @@ export default class Publisher {
 
         publishedFrontMatter = this.addPermalink(fileFrontMatter, publishedFrontMatter, file.path);
 		publishedFrontMatter = this.addDefaultPassThrough(fileFrontMatter, publishedFrontMatter);
-		publishedFrontMatter = this.addBodyClasses(fileFrontMatter, publishedFrontMatter);
+		publishedFrontMatter = this.addContentClasses(fileFrontMatter, publishedFrontMatter);
 		publishedFrontMatter = this.addPageTags(fileFrontMatter, publishedFrontMatter);
         publishedFrontMatter = this.addFrontMatterSettings(fileFrontMatter, publishedFrontMatter);
         publishedFrontMatter = this.addNoteIconFrontMatter(fileFrontMatter, publishedFrontMatter);
@@ -459,7 +459,7 @@ export default class Publisher {
         return publishedFrontMatter;
 	}
 
-	addBodyClasses(baseFrontMatter: any, newFrontMatter: any) {
+	addContentClasses(baseFrontMatter: any, newFrontMatter: any) {
 		const publishedFrontMatter = { ...newFrontMatter };
 		
 		if (baseFrontMatter) {

--- a/src/SettingView.ts
+++ b/src/SettingView.ts
@@ -331,9 +331,9 @@ export default class SettingView {
             .setName('Body Classes Key')
             .setDesc('Key to get classes to add in the note body from the frontmatter.')
             .addText(text =>
-                text.setValue(this.settings.bodyClassesKey)
+                text.setValue(this.settings.contentClassesKey)
                     .onChange(async (value) => {
-                        this.settings.bodyClassesKey = value;
+                        this.settings.contentClassesKey = value;
                         await this.saveSettings();
                     })
             );

--- a/src/SettingView.ts
+++ b/src/SettingView.ts
@@ -325,6 +325,17 @@ export default class SettingView {
                         this.settings.updatedTimestampKey = value;
                         await this.saveSettings();
                     })
+		);
+		
+		new Setting(themeModal.contentEl)
+            .setName('Body Classes Key')
+            .setDesc('Key to get classes to add in the note body from the frontmatter.')
+            .addText(text =>
+                text.setValue(this.settings.bodyClassesKey)
+                    .onChange(async (value) => {
+                        this.settings.bodyClassesKey = value;
+                        await this.saveSettings();
+                    })
             );
 
 


### PR DESCRIPTION
This PR allows users to:
1. Set a key from which the classes should be extracted (Defaults to `dg-content-classes`). This reconfigurability allows users to avoid redundancy. For example, the Minimal theme comes with its own key to set classes. Users can use the same values for the digital garden too.
2. Allow users to set classes to be added to the content container from the notes. It will allow users to do many style tweaks. For example card view.