### PR TITLE
fix: add support for dataview inside callouts blocks

### DIFF
--- a/src/Publisher.ts
+++ b/src/Publisher.ts
@@ -315,8 +315,7 @@ export default class Publisher {
                 let markdown = await dvApi.tryQueryMarkdown(finalQuery, path);
 
                 if (isInsideCallout) {
-                    const tmp = markdown.split("\n");
-                    markdown = " " + tmp.join("\n> ")
+                    markdown = this.surroundWithCalloutBlock(markdown)
                 }
                 replacedText = replacedText.replace(block, `${markdown}\n{ .block-language-dataview}`);            
             }catch(e){
@@ -337,8 +336,7 @@ export default class Publisher {
                 component.load();
                 let replacementString = div.innerHTML
                 if (isInsideCallout) {
-                    const tmp = replacementString.split("\n");
-                    replacementString = " " + tmp.join("\n> ")
+                    replacementString = this.surroundWithCalloutBlock(replacementString)
                 }
                 replacedText = replacedText.replace(block, replacementString);
             }catch(e){
@@ -384,6 +382,17 @@ export default class Publisher {
         }
        
         return replacedText;
+    }
+
+    /**
+     * Splits input in lines.
+     * Prepends the callout/quote sign to each line, 
+     * returns all the lines as a single string
+     * 
+     */
+    surroundWithCalloutBlock(input: string): string {
+        const tmp = input.split("\n");
+        return " " + tmp.join("\n> ")
     }
 
     /**


### PR DESCRIPTION
This should fix the error that appears when people try to push files containing dataview blocks inside callouts.

It does 2 things : 

- it tries to detect if the dataview query lines start with callout marker `>`
if yes, it strips the symbol and concatenates back the parts to restore a valid query

- after the markdown has been rendered by the dataview plugin, it adds callout markers in front of the generated markdown to restore original intent.

For example, this : 

```

> [!NOTE]+ Title
> Contents
> ```dataview
 TABLE
 FROM
 "test"
> ```

```

is transformed into this : 

```

> [!NOTE]+ Title
> Contents
>  | File                     |
> | ------------------------ |
> | [[test/note1\|note1]] |
> | [[test/note2\|note2]] |
> 
{ .block-language-dataview}
```

And this : 

```

> [!dice]+ Title
> Contents
> ```dataviewjs
>const note = dv.current();
>dv.header(1, `${note.file.name}`)
>```
>
> ###### Bio
>
>```dataviewjs
>const note = dv.current();
dv.span(`
 |**Race** | ${note.race}|
 |---|---|
 |**Class** | ${note.Class}  ${note.Level}|
 |**Age** | 30|
`)
>```
>
```

is rendered like this : 

```

> [!dice]+ Title
> Contents
>  <h1><span><p>test</p></span></h1>
>
> ###### Bio
>
> <span><span><table>
> <thead>
> <tr>
> <th><strong>Race</strong></th>
> <th>Human</th>
> </tr>
> </thead>
> <tbody>
> <tr>
> <td><strong>Class</strong></td>
> <td>Ranger  2</td>
> </tr>
> <tr>
> <td><strong>Age</strong></td>
> <td>30</td>
> </tr>
> </tbody>
> </table></span></span>
>

```

This PR does not seem to add regressions to inline queries behaviour.
