### PR TITLE
feat: custom filters

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -38,6 +38,7 @@ const DEFAULT_SETTINGS: DigitalGardenSettings = {
 
 	styleSettingsCss: '',
 	pathRewriteRules: '',
+	customFilters: [],
 
 	contentClassesKey: 'dg-content-classes',
 

--- a/src/DigitalGardenSettings.ts
+++ b/src/DigitalGardenSettings.ts
@@ -32,6 +32,7 @@ export default interface DigitalGardenSettings {
 
 	styleSettingsCss: string;
 	pathRewriteRules: string;
+	customFilters: Array<{pattern: string, flags: string, replace: string}>;
 	contentClassesKey: string;
 
 	defaultNoteSettings: {

--- a/src/SettingView.ts
+++ b/src/SettingView.ts
@@ -7,6 +7,7 @@ import { arrayBufferToBase64 } from './utils';
 import DigitalGarden from 'main';
 import DigitalGardenSiteManager from './DigitalGardenSiteManager';
 import { SvgFileSuggest } from './ui/file-suggest';
+import { addFilterInput } from './ui/addFilterInput';
 
 export default class SettingView {
     private app: App;
@@ -50,6 +51,7 @@ export default class SettingView {
 
         this.settingsRootElement.createEl('h3', { text: 'Advanced' }).prepend(getIcon("cog"));
 		this.initializePathRewriteSettings();
+		this.initializeCustomFilterSettings();
         prModal.titleEl.createEl("h1", "Site template settings");
     }
 
@@ -639,6 +641,49 @@ export default class SettingView {
                     })
 			}
             );
+    }
+
+    private initializeCustomFilterSettings() {
+
+        const customFilterModal = new Modal(this.app);
+        customFilterModal.titleEl.createEl("h1", {text: "Custom Filters"})
+        customFilterModal.modalEl.style.width = "fit-content";
+
+        new Setting(this.settingsRootElement)
+            .setName('Custom Filters')
+            .setDesc('Define custom rules to replace parts of the note before publishing.')
+            .addButton(cb=>{
+                cb.setButtonText("Manage Custom Filters")
+                cb.onClick(()=>{
+                    customFilterModal.open();
+                }) 
+            })
+
+        const rewritesettingContainer = customFilterModal.contentEl.createEl('div', { attr: { class: "", style: "align-items:flex-start; flex-direction: column; margin: 5px" } });
+		rewritesettingContainer.createEl('div').innerHTML = `Define regex filters to replace note content before publishing.`;
+        rewritesettingContainer.createEl('div', {attr: { class: "setting-item-description" }}).innerHTML = `Format: [<code>regex pattern</code>, <code>replacement</code>, <code>regex flags</code>]`;
+        rewritesettingContainer.createEl('div', {attr: { class: "setting-item-description" }}).innerHTML = `Example: filter [<code>:smile:</code>, <code>😀</code>, <code>g</code>] will replace text with real emojis`;
+
+        const customFilters = this.settings.customFilters;
+        new Setting(rewritesettingContainer)
+            .setName('Filters')
+            .addButton((button) => {
+                button.setButtonText("Add");
+                button.setTooltip("Add a filter");
+                button.setIcon('plus');
+                button.onClick(async () => {
+                    const customFilters = this.settings.customFilters;
+                    customFilters.push({pattern: '', flags: 'g', replace: ''});
+                    filterList.empty();
+                    for(let i = 0; i < customFilters.length; i++) {
+                        addFilterInput(customFilters[i], filterList, i, this);
+                    }
+                });
+            });
+        const filterList = rewritesettingContainer.createDiv('custom-filter-list');
+        for(let i = 0; i < customFilters.length; i++) {
+            addFilterInput(customFilters[i], filterList, i, this);
+        }
     }
 
     renderCreatePr(modal: Modal, handlePR: (button: ButtonComponent) => Promise<void>) {

--- a/src/ui/addFilterInput.ts
+++ b/src/ui/addFilterInput.ts
@@ -1,0 +1,68 @@
+import { ButtonComponent, TextComponent } from "obsidian";
+
+function addFilterInput(filter: { pattern: string, flags: string, replace: string }, el: HTMLElement, idx: number, plugin: any) {
+	console.log(typeof(plugin))
+	const item = el.createEl('li', { attr: { style: "list-style-type: none; position: relative; margin: 5px 0; padding-right: 45px" } });
+	const patternField = new TextComponent(el);
+	patternField.setPlaceholder("regex pattern")
+		.setValue(filter.pattern)
+		.onChange(async (value) => {
+			if (!value) {
+				return;
+			}
+			plugin.settings.customFilters[idx].pattern = value;
+			await plugin.saveSettings();
+		});
+	const patternEl = patternField.inputEl;
+	patternEl.style.width = "250px";
+	item.appendChild(patternEl);
+
+	const replaceField = new TextComponent(el);
+	replaceField.setPlaceholder("replacement")
+		.setValue(filter.replace)
+		.onChange(async (value) => {
+			if (!value) {
+				return;
+			}
+			plugin.settings.customFilters[idx].replace = value;
+			await plugin.saveSettings();
+		});
+	const replaceEl = replaceField.inputEl;
+	replaceEl.style.width = "250px";
+	replaceEl.style.marginLeft = "5px";
+	item.appendChild(replaceEl);
+
+	const flagField = new TextComponent(el);
+	flagField.setPlaceholder("flags")
+		.setValue(filter.flags)
+		.onChange(async (value) => {
+			if (!value) {
+				return;
+			}
+			plugin.settings.customFilters[idx].flags = value;
+			await plugin.saveSettings();
+		});
+	const flagEl = flagField.inputEl;
+	flagEl.style.width = "50px";
+	flagEl.style.marginLeft = "5px";
+	item.appendChild(flagEl);
+
+	const removeButton = new ButtonComponent(el);
+	removeButton.setIcon('minus');
+	removeButton.setTooltip("Remove filter");
+	removeButton.onClick(async () => {
+		plugin.settings.customFilters.splice(idx, 1);
+		el.empty();
+		for (let i = 0; i < plugin.settings.customFilters.length; i++) {
+			addFilterInput(plugin.settings.customFilters[i], el, i, plugin);
+		}
+		await plugin.saveSettings();
+	});
+	const removeButtonEl = removeButton.buttonEl;
+	removeButtonEl.style.marginLeft = "5px";
+	removeButtonEl.style.position = "absolute";
+	removeButtonEl.style.right = "0";
+	item.appendChild(removeButtonEl);
+}
+
+export { addFilterInput };


### PR DESCRIPTION
This feature potentially closes #77 and #302. Users can add custom filters (regex substitution) to replace parts of the note before publishing it. For example, with filter [`::: hidden(.*\n)*?:::`, ` `, `gm`], the following Markdown content will be removed before being sent to the remote repo:

```markdown
This is some normal text.

::: hidden
This is some private text that should not be published.
:::
```

For the UI, this feature adds a setting modal similar to `path rewrite rules` under the `Advanced` section:
<img width="703" alt="image" src="https://user-images.githubusercontent.com/48207708/237019301-19a84dbf-abf0-4d9c-8476-12d2db17a37a.png">

For the backend, this feature is just adding a `.replace()` call. However, I am unfamiliar with JS development and was just borrowing code from other parts of the plugin. Please feel free to adjust it as needed. If you think this feature is appropriate and ready, we can write some documents and examples for users' reference.