### PR TITLE
feat: Add ability to change path to notes in repository

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -38,6 +38,7 @@ const DEFAULT_SETTINGS: DigitalGardenSettings = {
 
 	styleSettingsCss: '',
 	pathRewriteRules: '',
+	pathToNotesInRepo: 'src/site/notes',
 
 	contentClassesKey: 'dg-content-classes',
 

--- a/src/DigitalGardenSettings.ts
+++ b/src/DigitalGardenSettings.ts
@@ -32,6 +32,7 @@ export default interface DigitalGardenSettings {
 
 	styleSettingsCss: string;
 	pathRewriteRules: string;
+	pathToNotesInRepo: string;
 	contentClassesKey: string;
 
 	defaultNoteSettings: {

--- a/src/DigitalGardenSiteManager.ts
+++ b/src/DigitalGardenSiteManager.ts
@@ -119,10 +119,10 @@ export default class DigitalGardenSiteManager implements IDigitalGardenSiteManag
 
         const files = response.data.tree;
         const notes: Array<{ path: string, sha: string }> = files.filter(
-            (x: { path: string; type: string; }) => x.path.startsWith("src/site/notes/") && x.type === "blob" && x.path !== "src/site/notes/notes.json");
+            (x: { path: string; type: string; }) => x.path.startsWith(this.settings.pathToNotesInRepo) && x.type === "blob" && x.path !== `${this.settings.pathToNotesInRepo}/notes.json`);
         const hashes: { [key: string]: string } = {};
         for (const note of notes) {
-            const vaultPath = note.path.replace("src/site/notes/", "");
+            const vaultPath = note.path.replace(`${this.settings.pathToNotesInRepo}/`, "");
             hashes[vaultPath] = note.sha;
         }
         return hashes;
@@ -320,6 +320,7 @@ export default class DigitalGardenSiteManager implements IDigitalGardenSiteManag
     }
 
     private async getPluginInfo(octokit: Octokit): Promise<DigitalGardenPluginInfo>{
+		debugger;
         const pluginInfoResponse = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
             owner: "oleeskild",
             repo: "digitalgarden",

--- a/src/Publisher.ts
+++ b/src/Publisher.ts
@@ -67,7 +67,7 @@ export default class Publisher {
     }
 
 	async deleteNote(vaultFilePath: string) {
-		const path = `src/site/notes/${vaultFilePath}`;
+		const path = `${this.settings.pathToNotesInRepo}/${vaultFilePath}`;
 		return await this.delete(path);
 	}
 
@@ -222,7 +222,7 @@ export default class Publisher {
 
     async uploadText(filePath: string, content: string) {
 		content = Base64.encode(content);
-        const path = `src/site/notes/${filePath}`
+        const path = `${this.settings.pathToNotesInRepo}/${filePath}`
         await this.uploadToGithub(path, content)
     }
 
@@ -441,6 +441,8 @@ export default class Publisher {
 		} else {
             publishedFrontMatter["permalink"] = "/" + generateUrlPath(gardenPath, this.settings.slugifyEnabled);
         }
+
+		publishedFrontMatter["permalink"] = publishedFrontMatter["permalink"].replaceAll("//", "/");
 
         return publishedFrontMatter;
     }

--- a/src/SettingView.ts
+++ b/src/SettingView.ts
@@ -50,6 +50,7 @@ export default class SettingView {
 
         this.settingsRootElement.createEl('h3', { text: 'Advanced' }).prepend(getIcon("cog"));
 		this.initializePathRewriteSettings();
+		this.initializePathToNotesSettings();
         prModal.titleEl.createEl("h1", "Site template settings");
     }
 
@@ -461,7 +462,8 @@ export default class SettingView {
         try {
             const gardenManager = new DigitalGardenSiteManager(metadataCache, settings)
             await gardenManager.updateEnv();
-        } catch {
+        } catch (error) {
+            console.error(error);
             new Notice("Failed to update settings. Make sure you have an internet connection.")
             updateFailed = true;
         }
@@ -639,6 +641,25 @@ export default class SettingView {
                     })
 			}
             );
+    }
+
+    private initializePathToNotesSettings() {
+        new Setting(this.settingsRootElement)
+            .setName('Root folder for notes in repository')
+            .setDesc(`
+            This change path for uploaded note in garden repository. Use only if you have different template for repository.
+			Last slash will be removed.
+            `)
+            .addText(text => text
+                .setPlaceholder('src/site/notes')
+                .setValue(this.settings.pathToNotesInRepo)
+                .onChange(async (value) => {
+					if (value.endsWith("/")) {
+						value = value.slice(0, -1);
+					}
+                    this.settings.pathToNotesInRepo = value;
+                    this.debouncedSaveAndUpdate(this.app.metadataCache, this.settings, this.saveSettings);
+                }));
     }
 
     renderCreatePr(modal: Modal, handlePR: (button: ButtonComponent) => Promise<void>) {


### PR DESCRIPTION
Placed in advance options, like rewritePath.
With these two options, digital garden is generally available for other templates.

This is a second try to implementation, but I think it will be good for advanced users. (: