### PR TITLE
fix: 🐛 set precedence of dg-permalink in transcluded text link

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,5 +99,15 @@ function fixSvgForXmlSerializer(svgElement: SVGSVGElement): void{
 	}
 }
 
+function sanitizePermalink(permalink: string): string {
+		if (!permalink.endsWith("/")) {
+			permalink += "/";
+		}
+		if (!permalink.startsWith("/")) {
+			permalink = "/" + permalink;
+		}
+		return permalink;
+	}
 
-export { arrayBufferToBase64, extractBaseUrl, generateUrlPath, generateBlobHash, kebabize, wrapAround, getRewriteRules, getVaultPathForNote, getGardenPathForNote, escapeRegExp, fixSvgForXmlSerializer};
+
+export { arrayBufferToBase64, extractBaseUrl, generateUrlPath, generateBlobHash, kebabize, wrapAround, getRewriteRules, getVaultPathForNote, getGardenPathForNote, escapeRegExp, fixSvgForXmlSerializer, sanitizePermalink};


### PR DESCRIPTION
Until now, `dg-permalink` was ignored while generating links to transcluded texts.

This PR fixes the issue.