### PR TITLE
If tags is string, split on commas assuming CSV formatting.

### DIFF
--- a/src/Publisher.ts
+++ b/src/Publisher.ts
@@ -457,7 +457,7 @@ export default class Publisher {
     addPageTags(baseFrontMatter: any, newFrontMatter: any) {
         const publishedFrontMatter = { ...newFrontMatter };
         if (baseFrontMatter) {
-            const tags = (typeof (baseFrontMatter["tags"]) === "string" ? [baseFrontMatter["tags"]] : baseFrontMatter["tags"]) || [];
+            const tags = (typeof (baseFrontMatter["tags"]) === "string" ? baseFrontMatter["tags"].split(/,\s*/) : baseFrontMatter["tags"]) || [];
             if (baseFrontMatter["dg-home"]) {
                 tags.push("gardenEntry")
             }


### PR DESCRIPTION
This should fix #358! I just split on any "string" tags on commas (plus any number of spaces) in order to generate an array of tags. 

I've tested it on my local environment and it works great. That said, I'm not certain that I've accounted for all edge cases, so please let me know if anything I've missed. Thanks!