### PR TITLE
settings: add live preview to path rewrite settings

### DIFF
--- a/src/SettingView.ts
+++ b/src/SettingView.ts
@@ -3,7 +3,7 @@ import { ButtonComponent, Modal, Notice, Setting, App, TFile, debounce, Metadata
 import axios from "axios";
 import { Octokit } from '@octokit/core';
 import { Base64 } from 'js-base64';
-import { arrayBufferToBase64 } from './utils';
+import { arrayBufferToBase64, getGardenPathForNote, getRewriteRules } from './utils';
 import DigitalGarden from 'main';
 import DigitalGardenSiteManager from './DigitalGardenSiteManager';
 import { SvgFileSuggest } from './ui/file-suggest';
@@ -41,7 +41,7 @@ export default class SettingView {
 
         this.settingsRootElement.createEl('h3', { text: 'URL' }).prepend(getIcon("link"));
         this.initializeGitHubBaseURLSetting();
-		this.initializeSlugifySetting();
+        this.initializeSlugifySetting();
 
         this.settingsRootElement.createEl('h3', { text: 'Features' }).prepend(getIcon("star"));
         this.initializeDefaultNoteSettings();
@@ -621,13 +621,19 @@ export default class SettingView {
             })
 
         const rewritesettingContainer = rewriteRulesModal.contentEl.createEl('div', { attr: { class: "", style: "align-items:flex-start; flex-direction: column;" } });
+
 		rewritesettingContainer.createEl('div', {text: `Define rules to rewrite note paths/folder structure, using following syntax:`})
+
         const list = rewritesettingContainer.createEl('ol');
         list.createEl("li", {text: `One rule-per line`})
         list.createEl("li", {text: `The format is [from_vault_path]:[to_garden_path]`})
         list.createEl("li", {text: `Matching will exit on first match`});
         rewritesettingContainer.createEl("div", {text: `Example: If you want the vault folder "Personal/Journal" to be shown as only "Journal" in the left file sidebar in the garden, add the line "Personal/Journal:Journal"`, attr: { class: "setting-item-description" }})
+		rewritesettingContainer.createEl("div", { text: `Note: rewriting a folder to the base path "[from_vault_path]:" is not supported at the moment.`, attr: { class: "setting-item-description" } })
         rewritesettingContainer.createEl("div", {text: `Any affected notes will show up as changed in the publication center`, attr: { class: "setting-item-description" }})
+
+
+
         new Setting(rewritesettingContainer)
             .setName('Rules')
 			.addTextArea(field => {
@@ -637,10 +643,28 @@ export default class SettingView {
 				field.setValue(this.settings.pathRewriteRules)
                     .onChange(async (value) => {
                         this.settings.pathRewriteRules = value;
-                        await this.saveSettings();
+						await this.saveSettings()
+
                     })
 			}
-            );
+		);	
+
+		rewritesettingContainer.createEl("div", { text: `Type a path below to test that your rules are working as expected`, attr: { class: "test-rewrite-rules-description" } })
+
+		const rewriteSettingsPreviewContainer = rewritesettingContainer.createEl('div', { attr: { style: 'display: flex; align-items: center; margin-top: 10px;' } });
+
+		const previewInput = rewriteSettingsPreviewContainer.createEl('input', { attr: { type: 'text', placeholder: 'type a vault path', style: 'margin-right: 10px;' } });
+
+		previewInput.addEventListener('input', () => {
+			const testPath = previewInput.value;
+			const rewriteTestResult = getGardenPathForNote(testPath, getRewriteRules(this.settings.pathRewriteRules));
+			testResultDiv.innerHTML = `Garden path: "${rewriteTestResult}"`;
+		});
+
+		const testResultDiv = rewriteSettingsPreviewContainer.createEl("div", { text: `Garden path: ""`, attr: { class: "test-rewrite-rules-new-path" } });
+
+
+
     }
 
     private initializeCustomFilterSettings() {


### PR DESCRIPTION
## This PR: 

- Adds field in rewrite rules settings which allows user to test their rules against any path they write. 

## Context 

Before attempting to fix https://github.com/oleeskild/obsidian-digital-garden/issues/289 I figured this would be a useful helper for 
1. verifying rules are working as intended 
2. documenting the rules in practice! 

I noticed while writing my own rules that to be sure the rules were working correctly I would have to set them, publish garden, go to garden and verify. 

![CleanShot 2023-08-21 at 18 52 47](https://github.com/oleeskild/obsidian-digital-garden/assets/4622905/d124ed2d-3fdb-4af3-9346-8438fbf38314)
