### PR TITLE
Fix final type problems

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,7 @@
 				"caughtErrorsIgnorePattern": "^_"
 			}
 		],
-		"@typescript-eslint/no-explicit-any": ["warn"],
+		"@typescript-eslint/no-explicit-any": ["error"],
 		// allow prettier to use SmartTabs
 		"no-mixed-spaces-and-tabs": "off"
 	}

--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,6 @@
 		],
 		"@typescript-eslint/no-explicit-any": ["warn"],
 		// allow prettier to use SmartTabs
-		"no-mixed-spaces-and-tabs": "off",
+		"no-mixed-spaces-and-tabs": "off"
 	}
 }

--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -1,0 +1,3 @@
+const obsidian = {};
+
+module.exports = obsidian;

--- a/main.ts
+++ b/main.ts
@@ -1,21 +1,13 @@
-import {
-	App,
-	ButtonComponent,
-	Modal,
-	Notice,
-	Plugin,
-	PluginSettingTab,
-	addIcon,
-} from "obsidian";
+import { Notice, Plugin, addIcon } from "obsidian";
 import Publisher from "./src/Publisher";
 import DigitalGardenSettings from "./src/DigitalGardenSettings";
-import SettingView from "./src/SettingView";
 import { PublishStatusBar } from "./src/PublishStatusBar";
 import { seedling } from "./src/constants";
 import { PublishModal } from "./src/PublishModal";
 import PublishStatusManager from "./src/PublishStatusManager";
 import ObsidianFrontMatterEngine from "./src/ObsidianFrontMatterEngine";
 import DigitalGardenSiteManager from "./src/DigitalGardenSiteManager";
+import { DigitalGardenSettingTab } from "./src/ui/DigitalGardenSettingTab";
 
 const DEFAULT_SETTINGS: DigitalGardenSettings = {
 	githubRepo: "",
@@ -374,65 +366,5 @@ export default class DigitalGarden extends Plugin {
 			);
 		}
 		this.publishModal.open();
-	}
-}
-
-class DigitalGardenSettingTab extends PluginSettingTab {
-	plugin: DigitalGarden;
-
-	constructor(app: App, plugin: DigitalGarden) {
-		super(app, plugin);
-		this.plugin = plugin;
-
-		if (!this.plugin.settings.noteSettingsIsInitialized) {
-			const siteManager = new DigitalGardenSiteManager(
-				this.app.metadataCache,
-				this.plugin.settings,
-			);
-			siteManager.updateEnv();
-			this.plugin.settings.noteSettingsIsInitialized = true;
-			this.plugin.saveData(this.plugin.settings);
-		}
-	}
-
-	async display(): Promise<void> {
-		const { containerEl } = this;
-		const settingView = new SettingView(
-			this.app,
-			containerEl,
-			this.plugin.settings,
-			async () => await this.plugin.saveData(this.plugin.settings),
-		);
-		const prModal = new Modal(this.app);
-		await settingView.initialize(prModal);
-
-		const handlePR = async (button: ButtonComponent) => {
-			settingView.renderLoading();
-			button.setDisabled(true);
-
-			try {
-				const siteManager = new DigitalGardenSiteManager(
-					this.plugin.app.metadataCache,
-					this.plugin.settings,
-				);
-
-				const prUrl =
-					await siteManager.createPullRequestWithSiteChanges();
-
-				if (prUrl) {
-					this.plugin.settings.prHistory.push(prUrl);
-					await this.plugin.saveSettings();
-				}
-				settingView.renderSuccess(prUrl);
-				button.setDisabled(false);
-			} catch {
-				settingView.renderError();
-			}
-		};
-		settingView.renderCreatePr(prModal, handlePR);
-		settingView.renderPullRequestHistory(
-			prModal,
-			this.plugin.settings.prHistory.reverse().slice(0, 10),
-		);
 	}
 }

--- a/src/DigitalGardenSiteManager.ts
+++ b/src/DigitalGardenSiteManager.ts
@@ -112,7 +112,7 @@ export default class DigitalGardenSiteManager {
 
 		let urlPath = `/${noteUrlPath}`;
 
-		const frontMatter = this.metadataCache.getCache(file.path).frontmatter;
+		const frontMatter = this.metadataCache.getCache(file.path)?.frontmatter;
 
 		if (frontMatter && frontMatter["dg-home"] === true) {
 			urlPath = "/";
@@ -253,9 +253,7 @@ export default class DigitalGardenSiteManager {
 
 			return pr.data.html_url;
 		} catch {
-			// The PR failed, most likely the repo is the latest version
-			// probably want to throw here
-			return;
+			throw new Error("Unable to create PR");
 		}
 	}
 

--- a/src/SettingView.ts
+++ b/src/SettingView.ts
@@ -20,7 +20,6 @@ import {
 import DigitalGardenSiteManager from "./DigitalGardenSiteManager";
 import { SvgFileSuggest } from "./ui/file-suggest";
 import { addFilterInput } from "./ui/addFilterInput";
-import { UpdateGardenRepositoryModal } from "./ui/SettingsModal";
 
 interface IObsidianTheme {
 	name: string;
@@ -113,7 +112,7 @@ export default class SettingView {
 	}
 
 	private async initializeDefaultNoteSettings() {
-		const noteSettingsModal = new UpdateGardenRepositoryModal(this.app);
+		const noteSettingsModal = new Modal(this.app);
 		noteSettingsModal.titleEl.createEl("h1", {
 			text: "Default Note Settings",
 		});
@@ -313,7 +312,7 @@ export default class SettingView {
 	}
 
 	private async initializeThemesSettings() {
-		const themeModal = new UpdateGardenRepositoryModal(this.app);
+		const themeModal = new Modal(this.app);
 		themeModal.containerEl.addClass("dg-settings");
 		themeModal.titleEl.createEl("h1", { text: "Appearance Settings" });
 
@@ -983,7 +982,7 @@ export default class SettingView {
 	}
 
 	renderCreatePr(
-		modal: UpdateGardenRepositoryModal,
+		modal: Modal,
 		handlePR: (button: ButtonComponent) => Promise<void>,
 	) {
 		this.settingsRootElement

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -1,7 +1,7 @@
 import { FrontMatterCache, Notice } from "obsidian";
 
-export function validatePublishFrontmatter(
-	frontMatter: FrontMatterCache,
+export function isPublishFrontmatterValid(
+	frontMatter?: FrontMatterCache,
 ): boolean {
 	if (!frontMatter || !frontMatter["dg-publish"]) {
 		new Notice(

--- a/src/test/Publisher.test.ts
+++ b/src/test/Publisher.test.ts
@@ -1,0 +1,53 @@
+import DigitalGardenSettings from "../DigitalGardenSettings";
+import Publisher from "../Publisher";
+jest.mock("obsidian");
+
+describe("Publisher", () => {
+	describe("generateTransclusionHeader", () => {
+		const getTestPublisher = (settings: Partial<DigitalGardenSettings>) => {
+			return new Publisher(
+				{} as any,
+				{} as any,
+				{ pathRewriteRules: "", ...settings } as DigitalGardenSettings,
+			);
+		};
+
+		it("should replace {{title}} with the basename of the file", () => {
+			const testPublisher = getTestPublisher({});
+			const EXPECTED_TITLE = "expected";
+			const result = testPublisher.generateTransclusionHeader(
+				"# {{header}}",
+				{ basename: EXPECTED_TITLE } as any,
+			);
+
+			expect(result).toBe(`# ${EXPECTED_TITLE}`);
+		});
+		it("should add # to header if it is not a markdown header", () => {
+			const testPublisher = getTestPublisher({});
+			const result = testPublisher.generateTransclusionHeader(
+				"header",
+				{} as any,
+			);
+
+			expect(result).toBe(`# header`);
+		});
+		it("Ensures that header has space after #", () => {
+			const testPublisher = getTestPublisher({});
+			const result = testPublisher.generateTransclusionHeader(
+				"###header",
+				{} as any,
+			);
+
+			expect(result).toBe(`### header`);
+		});
+		it("Returns undefined if heading is undefined", () => {
+			const testPublisher = getTestPublisher({});
+			const result = testPublisher.generateTransclusionHeader(
+				undefined,
+				{} as any,
+			);
+
+			expect(result).toBe(undefined);
+		});
+	});
+});

--- a/src/test/Publisher.test.ts
+++ b/src/test/Publisher.test.ts
@@ -1,3 +1,4 @@
+import { MetadataCache, TFile, Vault } from "obsidian";
 import DigitalGardenSettings from "../DigitalGardenSettings";
 import Publisher from "../Publisher";
 jest.mock("obsidian");
@@ -6,8 +7,8 @@ describe("Publisher", () => {
 	describe("generateTransclusionHeader", () => {
 		const getTestPublisher = (settings: Partial<DigitalGardenSettings>) => {
 			return new Publisher(
-				{} as any,
-				{} as any,
+				{} as unknown as Vault,
+				{} as unknown as MetadataCache,
 				{ pathRewriteRules: "", ...settings } as DigitalGardenSettings,
 			);
 		};
@@ -16,8 +17,8 @@ describe("Publisher", () => {
 			const testPublisher = getTestPublisher({});
 			const EXPECTED_TITLE = "expected";
 			const result = testPublisher.generateTransclusionHeader(
-				"# {{header}}",
-				{ basename: EXPECTED_TITLE } as any,
+				"# {{title}}",
+				{ basename: EXPECTED_TITLE } as TFile,
 			);
 
 			expect(result).toBe(`# ${EXPECTED_TITLE}`);
@@ -26,7 +27,7 @@ describe("Publisher", () => {
 			const testPublisher = getTestPublisher({});
 			const result = testPublisher.generateTransclusionHeader(
 				"header",
-				{} as any,
+				{} as TFile,
 			);
 
 			expect(result).toBe(`# header`);
@@ -35,7 +36,7 @@ describe("Publisher", () => {
 			const testPublisher = getTestPublisher({});
 			const result = testPublisher.generateTransclusionHeader(
 				"###header",
-				{} as any,
+				{} as TFile,
 			);
 
 			expect(result).toBe(`### header`);
@@ -44,7 +45,7 @@ describe("Publisher", () => {
 			const testPublisher = getTestPublisher({});
 			const result = testPublisher.generateTransclusionHeader(
 				undefined,
-				{} as any,
+				{} as TFile,
 			);
 
 			expect(result).toBe(undefined);

--- a/src/ui/DigitalGardenSettingTab.ts
+++ b/src/ui/DigitalGardenSettingTab.ts
@@ -1,0 +1,65 @@
+import { PluginSettingTab, App, ButtonComponent } from "obsidian";
+import DigitalGarden from "../../main";
+import DigitalGardenSiteManager from "../DigitalGardenSiteManager";
+import SettingView from "../SettingView";
+import { UpdateGardenRepositoryModal } from "./SettingsModal";
+
+export class DigitalGardenSettingTab extends PluginSettingTab {
+	plugin: DigitalGarden;
+
+	constructor(app: App, plugin: DigitalGarden) {
+		super(app, plugin);
+		this.plugin = plugin;
+
+		if (!this.plugin.settings.noteSettingsIsInitialized) {
+			const siteManager = new DigitalGardenSiteManager(
+				this.app.metadataCache,
+				this.plugin.settings,
+			);
+			siteManager.updateEnv();
+			this.plugin.settings.noteSettingsIsInitialized = true;
+			this.plugin.saveData(this.plugin.settings);
+		}
+	}
+
+	async display(): Promise<void> {
+		const { containerEl } = this;
+		const settingView = new SettingView(
+			this.app,
+			containerEl,
+			this.plugin.settings,
+			async () => await this.plugin.saveData(this.plugin.settings),
+		);
+		const prModal = new UpdateGardenRepositoryModal(this.app);
+		await settingView.initialize(prModal);
+
+		const handlePR = async (button: ButtonComponent) => {
+			prModal.renderLoading();
+			button.setDisabled(true);
+
+			try {
+				const siteManager = new DigitalGardenSiteManager(
+					this.plugin.app.metadataCache,
+					this.plugin.settings,
+				);
+
+				const prUrl =
+					await siteManager.createPullRequestWithSiteChanges();
+
+				if (prUrl) {
+					this.plugin.settings.prHistory.push(prUrl);
+					await this.plugin.saveSettings();
+				}
+				prModal.renderSuccess(prUrl);
+				button.setDisabled(false);
+			} catch {
+				prModal.renderError();
+			}
+		};
+		settingView.renderCreatePr(prModal, handlePR);
+		settingView.renderPullRequestHistory(
+			prModal,
+			this.plugin.settings.prHistory.reverse().slice(0, 10),
+		);
+	}
+}

--- a/src/ui/SettingsModal.ts
+++ b/src/ui/SettingsModal.ts
@@ -1,0 +1,58 @@
+import { App, Modal } from "obsidian";
+
+export class UpdateGardenRepositoryModal extends Modal {
+	loading: HTMLElement | undefined;
+	loadingInterval: NodeJS.Timeout | undefined;
+	progressViewTop: HTMLElement;
+
+	constructor(app: App) {
+		super(app);
+		this.progressViewTop = this.contentEl.createDiv();
+	}
+
+	renderLoading() {
+		this.loading = this.progressViewTop.createDiv();
+		this.loading.show();
+		const text = "Creating PR. This should take about 30-60 seconds";
+
+		const loadingText = this.loading?.createEl("h5", { text });
+		this.loadingInterval = setInterval(() => {
+			if (loadingText.innerText === `${text}`) {
+				loadingText.innerText = `${text}.`;
+			} else if (loadingText.innerText === `${text}.`) {
+				loadingText.innerText = `${text}..`;
+			} else if (loadingText.innerText === `${text}..`) {
+				loadingText.innerText = `${text}...`;
+			} else {
+				loadingText.innerText = `${text}`;
+			}
+		}, 400);
+	}
+
+	renderSuccess(prUrl: string) {
+		this.loading?.remove();
+		clearInterval(this.loadingInterval);
+
+		const successmessage = prUrl
+			? { text: `🎉 Done! Approve your PR to make the changes go live.` }
+			: {
+					text: "You already have the latest template 🎉 No need to create a PR.",
+			  };
+		const linkText = { text: `${prUrl}`, href: prUrl };
+		this.progressViewTop.createEl("h2", successmessage);
+		if (prUrl) {
+			this.progressViewTop.createEl("a", linkText);
+		}
+		this.progressViewTop.createEl("br");
+	}
+
+	renderError() {
+		this.loading?.remove();
+		clearInterval(this.loadingInterval);
+		const errorMsg = {
+			text: "❌ Something went wrong. Try deleting the branch in GitHub.",
+			attr: {},
+		};
+		this.progressViewTop.createEl("p", errorMsg);
+	}
+}

--- a/src/ui/file-suggest.ts
+++ b/src/ui/file-suggest.ts
@@ -1,6 +1,5 @@
 //https://github.com/liamcain/obsidian-periodic-notes/blob/main/src/ui/file-suggest.ts
 import { TAbstractFile, TFile, TFolder } from "obsidian";
-
 import { TextInputSuggest } from "./suggest";
 
 export class SvgFileSuggest extends TextInputSuggest<TFile> {

--- a/src/ui/suggest.ts
+++ b/src/ui/suggest.ts
@@ -6,7 +6,7 @@ import { wrapAround } from "../utils";
 class Suggest<T> {
 	private owner: ISuggestOwner<T>;
 	private values: T[];
-	private suggestions: HTMLDivElement[];
+	private suggestions: HTMLElement[];
 	private selectedItem: number;
 	private containerEl: HTMLElement;
 
@@ -17,6 +17,9 @@ class Suggest<T> {
 	) {
 		this.owner = owner;
 		this.containerEl = containerEl;
+		this.suggestions = [];
+		this.selectedItem = 0;
+		this.values = [];
 
 		containerEl.on(
 			"click",
@@ -51,7 +54,7 @@ class Suggest<T> {
 		});
 	}
 
-	onSuggestionClick(event: MouseEvent, el: HTMLDivElement): void {
+	onSuggestionClick(event: MouseEvent, el: HTMLElement): void {
 		event.preventDefault();
 
 		const item = this.suggestions.indexOf(el);
@@ -59,7 +62,7 @@ class Suggest<T> {
 		this.useSelectedItem(event);
 	}
 
-	onSuggestionMouseover(_event: MouseEvent, el: HTMLDivElement): void {
+	onSuggestionMouseover(_event: MouseEvent, el: HTMLElement): void {
 		const item = this.suggestions.indexOf(el);
 		this.setSelectedItem(item, false);
 	}

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,22 @@
+const seperateHashesFromHeader = (
+	rawHeading: string,
+): { hashes: string; title: string } => {
+	const regex = /^(?<hashes>#+)(?<space>\s?)(?<title>.*)$/;
+	const matches = rawHeading.match(regex);
+
+	if (matches?.groups) {
+		const { hashes, _space, title } = matches.groups;
+		return {
+			hashes,
+			title,
+		};
+	}
+	// always return one hash for valid md heading
+	return { hashes: "#", title: rawHeading.trim() };
+};
+
+export const fixMarkdownHeaderSyntax = (rawHeading: string): string => {
+	const { hashes, title } = seperateHashesFromHeader(rawHeading);
+
+	return `${hashes} ${title}`;
+};


### PR DESCRIPTION
Fixes final type issues, all CI checks should be green. 

- adds a bunch of `.?`
- moves PR modal to seperate class 
- tests and refactors title checking

follows structure from https://github.com/oleeskild/obsidian-digital-garden/pull/397 so should rebase nicely. 

after this is in enforcing type-passing becomes easy! 