### PR TITLE
Show github connection status

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,6 @@ coverage
 
 *.yml
 src/dg-testVault/*
+
+package-lock.json
+package.json

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -1,3 +1,4 @@
+/** Saved to data.json, changing requires a migration */
 export default interface DigitalGardenSettings {
 	githubToken: string;
 	githubRepo: string;

--- a/src/publisher/Publisher.ts
+++ b/src/publisher/Publisher.ts
@@ -22,11 +22,11 @@ import {
 	sanitizePermalink,
 } from "../utils/utils";
 import { isPublishFrontmatterValid } from "./Validator";
-import { excaliDrawBundle, excalidraw } from "src/ui/suggest/constants";
 import slugify from "@sindresorhus/slugify";
 import { PathRewriteRules } from "./DigitalGardenSiteManager";
-import DigitalGardenSettings from "src/models/settings";
-import { fixMarkdownHeaderSyntax } from "src/utils/markdown";
+import DigitalGardenSettings from "../models/settings";
+import { excaliDrawBundle, excalidraw } from "../ui/suggest/constants";
+import { fixMarkdownHeaderSyntax } from "../utils/markdown";
 
 export interface MarkedForPublishing {
 	notes: TFile[];

--- a/src/test/Publisher.test.ts
+++ b/src/test/Publisher.test.ts
@@ -1,6 +1,7 @@
 import { MetadataCache, TFile, Vault } from "obsidian";
-import DigitalGardenSettings from "../DigitalGardenSettings";
-import Publisher from "../Publisher";
+import DigitalGardenSettings from "../models/settings";
+import Publisher from "../publisher/Publisher";
+
 jest.mock("obsidian");
 
 describe("Publisher", () => {

--- a/src/ui/SettingsView/GithubSettings.ts
+++ b/src/ui/SettingsView/GithubSettings.ts
@@ -1,0 +1,135 @@
+import { Setting } from "obsidian";
+import SettingView from "./SettingView";
+import { Octokit } from "@octokit/core";
+
+export class GithubSettings {
+	settings: SettingView;
+	connectionStatus: "loading" | "connected" | "error";
+	private settingsRootElement: HTMLElement;
+	connectionStatusElement: HTMLElement;
+
+	constructor(settings: SettingView, settingsRootElement: HTMLElement) {
+		this.settings = settings;
+		this.settingsRootElement = settingsRootElement;
+		this.settingsRootElement.id = "github-settings";
+		this.settingsRootElement.classList.add("settings-tab-content");
+		this.connectionStatus = "loading";
+		this.connectionStatusElement = this.settingsRootElement.createEl(
+			"span",
+			{ cls: "connection-status" },
+		);
+		this.initializeHeader();
+		this.initializeGitHubRepoSetting();
+		this.initializeGitHubUserNameSetting();
+		this.initializeGitHubTokenSetting();
+	}
+
+	initializeHeader = () => {
+		this.connectionStatusElement.style.cssText = "margin-left: 10px;";
+		this.checkConnectionAndSaveSettings();
+		const githubSettingsHeader = createEl("h3", {
+			text: "GitHub Authentication (required)",
+		});
+		githubSettingsHeader.append(this.connectionStatusElement);
+		githubSettingsHeader.prepend(this.settings.getIcon("github"));
+
+		this.settingsRootElement.prepend(githubSettingsHeader);
+	};
+
+	checkConnectionAndSaveSettings = async () => {
+		this.settings.saveSettings();
+		await this.updateConnectionStatus();
+	};
+
+	updateConnectionStatus = async () => {
+		const oktokit = new Octokit({
+			auth: this.settings.settings.githubToken,
+		});
+
+		try {
+			const response = await oktokit.request(
+				"GET /repos/{owner}/{repo}",
+				{
+					owner: this.settings.settings.githubUserName,
+					repo: this.settings.settings.githubRepo,
+				},
+			);
+			// If other permissions are needed, add them here and indicate to user on insufficient permissions
+			// Github now advocates for hyper-specific tokens
+			if (response.data.permissions?.admin) {
+				this.connectionStatus = "connected";
+			}
+		} catch (error) {
+			this.connectionStatus = "error";
+		}
+		this.updateConnectionStatusIndicator();
+	};
+
+	updateConnectionStatusIndicator = () => {
+		if (this.connectionStatus === "loading") {
+			this.connectionStatusElement.innerText = "⏳";
+		}
+		if (this.connectionStatus === "connected") {
+			this.connectionStatusElement.innerText = "✅";
+		}
+		if (this.connectionStatus === "error") {
+			this.connectionStatusElement.innerText = "❌";
+		}
+	};
+
+	private initializeGitHubRepoSetting() {
+		new Setting(this.settingsRootElement)
+			.setName("GitHub repo name")
+			.setDesc("The name of the GitHub repository")
+			.addText((text) =>
+				text
+					.setPlaceholder("mydigitalgarden")
+					.setValue(this.settings.settings.githubRepo)
+					.onChange(async (value) => {
+						this.settings.settings.githubRepo = value;
+						await this.checkConnectionAndSaveSettings();
+					}),
+			);
+	}
+
+	private initializeGitHubUserNameSetting() {
+		new Setting(this.settingsRootElement)
+			.setName("GitHub Username")
+			.setDesc("Your GitHub Username")
+			.addText((text) =>
+				text
+					.setPlaceholder("myusername")
+					.setValue(this.settings.settings.githubUserName)
+					.onChange(async (value) => {
+						this.settings.settings.githubUserName = value;
+						await this.checkConnectionAndSaveSettings();
+					}),
+			);
+	}
+
+	private initializeGitHubTokenSetting() {
+		const desc = document.createDocumentFragment();
+		desc.createEl("span", undefined, (span) => {
+			span.innerText =
+				"A GitHub token with repo permissions. You can generate it ";
+			span.createEl("a", undefined, (link) => {
+				link.href =
+					"https://github.com/settings/tokens/new?scopes=repo";
+				link.innerText = "here!";
+			});
+		});
+
+		new Setting(this.settingsRootElement)
+			.setName("GitHub token")
+			.setDesc(desc)
+			.addText((text) =>
+				text
+					.setPlaceholder("Secret Token")
+					.setValue(this.settings.settings.githubToken)
+					.onChange(async (value) => {
+						this.settings.settings.githubToken = value;
+						await this.checkConnectionAndSaveSettings();
+					}),
+			);
+	}
+}

--- a/src/ui/SettingsView/SettingView.ts
+++ b/src/ui/SettingsView/SettingView.ts
@@ -20,6 +20,7 @@ import {
 import DigitalGardenSiteManager from "src/publisher/DigitalGardenSiteManager";
 import { SvgFileSuggest } from "../suggest/file-suggest";
 import { addFilterInput } from "./addFilterInput";
+import { GithubSettings } from "./GithubSettings";
 
 interface IObsidianTheme {
 	name: string;
@@ -80,12 +81,11 @@ export default class SettingView {
 			href: "https://dg-docs.ole.dev/getting-started/01-getting-started/",
 		});
 
-		this.settingsRootElement
-			.createEl("h3", { text: "GitHub Authentication (required)" })
-			.prepend(this.getIcon("github"));
-		this.initializeGitHubRepoSetting();
-		this.initializeGitHubUserNameSetting();
-		this.initializeGitHubTokenSetting();
+		const githubSettings = this.settingsRootElement.createEl("div", {
+			cls: "connection-status",
+		});
+
+		new GithubSettings(this, githubSettings);
 
 		this.settingsRootElement
 			.createEl("h3", { text: "URL" })
@@ -720,61 +720,6 @@ export default class SettingView {
 				sha: faviconExists ? currentFaviconOnSite.data.sha : null,
 			});
 		}
-	}
-	private initializeGitHubRepoSetting() {
-		new Setting(this.settingsRootElement)
-			.setName("GitHub repo name")
-			.setDesc("The name of the GitHub repository")
-			.addText((text) =>
-				text
-					.setPlaceholder("mydigitalgarden")
-					.setValue(this.settings.githubRepo)
-					.onChange(async (value) => {
-						this.settings.githubRepo = value;
-						await this.saveSettings();
-					}),
-			);
-	}
-
-	private initializeGitHubUserNameSetting() {
-		new Setting(this.settingsRootElement)
-			.setName("GitHub Username")
-			.setDesc("Your GitHub Username")
-			.addText((text) =>
-				text
-					.setPlaceholder("myusername")
-					.setValue(this.settings.githubUserName)
-					.onChange(async (value) => {
-						this.settings.githubUserName = value;
-						await this.saveSettings();
-					}),
-			);
-	}
-
-	private initializeGitHubTokenSetting() {
-		const desc = document.createDocumentFragment();
-		desc.createEl("span", undefined, (span) => {
-			span.innerText =
-				"A GitHub token with repo permissions. You can generate it ";
-			span.createEl("a", undefined, (link) => {
-				link.href =
-					"https://github.com/settings/tokens/new?scopes=repo";
-				link.innerText = "here!";
-			});
-		});
-
-		new Setting(this.settingsRootElement)
-			.setName("GitHub token")
-			.setDesc(desc)
-			.addText((text) =>
-				text
-					.setPlaceholder("Secret Token")
-					.setValue(this.settings.githubToken)
-					.onChange(async (value) => {
-						this.settings.githubToken = value;
-						await this.saveSettings();
-					}),
-			);
 	}
 
 	private initializeGitHubBaseURLSetting() {


### PR DESCRIPTION
Small feature, will hopefully make setting up easier for less tech savvy people. 

Just adds an emoji which indicates connection status. 

Also allows for validating token permissions in future (github is advocating for less powerful and more specific tokens (which is good)). Also indicates if token has expired! 

This should probably be debounced though, but these are mostly pasted so it's not that bad. 

![CleanShot 2023-09-16 at 20 43 31](https://github.com/oleeskild/obsidian-digital-garden/assets/4622905/338b274a-c9df-4dd7-a2c1-8e6f5060ff7f)

