### PR TITLE
publishModal: revise publish modal styles

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ build
 main.js
 
 esbuild.config.mjs
+package-lock.json
 
 node_modules
 coverage

--- a/package.json
+++ b/package.json
@@ -1,64 +1,64 @@
 {
-  "name": "obsidian-garden",
-  "version": "1.0.0",
-  "description": "A plugin used for publishing notes to a digital garden",
-  "main": "main.js",
-  "scripts": {
-    "dev": "node esbuild.config.mjs",
-    "postdev": "copyfiles main.js manifest.json styles.css src/dg-testVault/.obsidian/plugins/obsidian-digital-garden/",
-    "dev1": "parcel main.ts",
-    "build": "node esbuild.config.mjs production",
-    "test": "jest",
-    "prepare": "husky install",
-    "lint": "eslint . --ext .ts",
-    "lint-fix": "eslint .  --fix  --ext .ts",
-    "format": "prettier --write .",
-    "check-formatting": "prettier --check .",
-    "typecheck": "tsc"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
-  "devDependencies": {
-    "@tsconfig/svelte": "^5.0.2",
-    "@types/crypto-js": "^4.1.2",
-    "@types/jest": "^29.5.4",
-    "@types/luxon": "^3.3.2",
-    "@types/node": "^20.6.0",
-    "@typescript-eslint/eslint-plugin": "^6.7.0",
-    "@typescript-eslint/parser": "^6.7.0",
-    "builtin-modules": "^3.3.0",
-    "esbuild": "^0.19.2",
-    "esbuild-svelte": "^0.8.0",
-    "eslint": "^8.49.0",
-    "eslint-plugin-prettier": "^5.0.0",
-    "husky": "^8.0.3",
-    "jest": "^29.7.0",
-    "lint-staged": "^14.0.1",
-    "obsidian": "^1.4.11",
-    "prettier": "3.0.3",
-    "svelte": "^4.2.0",
-    "svelte-preprocess": "^5.0.4",
-    "ts-jest": "^29.1.1",
-    "tslib": "^2.6.2",
-    "typescript": "^5.2.2",
-    "copyfiles": "^2.4.1"
-  },
-  "dependencies": {
-    "@octokit/core": "^5.0.0",
-    "@popperjs/core": "^2.11.8",
-    "@sindresorhus/slugify": "^1.1.2",
-    "axios": "^1.5.0",
-    "crypto-js": "^4.1.1",
-    "js-base64": "^3.7.5",
-    "luxon": "^3.4.3",
-    "lz-string": "^1.5.0",
-    "obsidian-dataview": "^0.5.56"
-  },
-  "lint-staged": {
-    "*.{ts}": [
-      "prettier --write",
-      "eslint --fix ."
-    ]
-  }
+	"name": "obsidian-garden",
+	"version": "1.0.0",
+	"description": "A plugin used for publishing notes to a digital garden",
+	"main": "main.js",
+	"scripts": {
+		"dev": "node esbuild.config.mjs",
+		"postdev": "copyfiles main.js manifest.json styles.css src/dg-testVault/.obsidian/plugins/obsidian-digital-garden/",
+		"dev1": "parcel main.ts",
+		"build": "node esbuild.config.mjs production",
+		"test": "jest",
+		"prepare": "husky install",
+		"lint": "eslint . --ext .ts",
+		"lint-fix": "eslint .  --fix  --ext .ts",
+		"format": "prettier --write .",
+		"check-formatting": "prettier --check .",
+		"typecheck": "tsc"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "MIT",
+	"devDependencies": {
+		"@tsconfig/svelte": "^5.0.2",
+		"@types/crypto-js": "^4.1.2",
+		"@types/jest": "^29.5.4",
+		"@types/luxon": "^3.3.2",
+		"@types/node": "^20.6.0",
+		"@typescript-eslint/eslint-plugin": "^6.7.0",
+		"@typescript-eslint/parser": "^6.7.0",
+		"builtin-modules": "^3.3.0",
+		"esbuild": "^0.19.2",
+		"esbuild-svelte": "^0.8.0",
+		"eslint": "^8.49.0",
+		"eslint-plugin-prettier": "^5.0.0",
+		"husky": "^8.0.3",
+		"jest": "^29.7.0",
+		"lint-staged": "^14.0.1",
+		"obsidian": "^1.4.11",
+		"prettier": "3.0.3",
+		"svelte": "^4.2.0",
+		"svelte-preprocess": "^5.0.4",
+		"ts-jest": "^29.1.1",
+		"tslib": "^2.6.2",
+		"typescript": "^5.2.2",
+		"copyfiles": "^2.4.1"
+	},
+	"dependencies": {
+		"@octokit/core": "^5.0.0",
+		"@popperjs/core": "^2.11.8",
+		"@sindresorhus/slugify": "^1.1.2",
+		"axios": "^1.5.0",
+		"crypto-js": "^4.1.1",
+		"js-base64": "^3.7.5",
+		"luxon": "^3.4.3",
+		"lz-string": "^1.5.0",
+		"obsidian-dataview": "^0.5.56"
+	},
+	"lint-staged": {
+		"*.{ts}": [
+			"prettier --write",
+			"eslint --fix ."
+		]
+	}
 }

--- a/src/dg-testVault/.obsidian/command-palette.json
+++ b/src/dg-testVault/.obsidian/command-palette.json
@@ -1,0 +1,6 @@
+{
+  "pinned": [
+    "app:reload",
+    "digitalgarden:dg-mark-note-for-publish"
+  ]
+}

--- a/src/dg-testVault/.obsidian/core-plugins-migration.json
+++ b/src/dg-testVault/.obsidian/core-plugins-migration.json
@@ -13,7 +13,7 @@
   "templates": true,
   "note-composer": true,
   "command-palette": true,
-  "slash-command": false,
+  "slash-command": true,
   "editor-status": true,
   "bookmarks": true,
   "markdown-importer": false,

--- a/src/dg-testVault/.obsidian/core-plugins.json
+++ b/src/dg-testVault/.obsidian/core-plugins.json
@@ -12,6 +12,7 @@
   "templates",
   "note-composer",
   "command-palette",
+  "slash-command",
   "editor-status",
   "bookmarks",
   "outline",

--- a/src/ui/PublishModal.ts
+++ b/src/ui/PublishModal.ts
@@ -43,7 +43,7 @@ export class PublishModal {
 	): HTMLElement[] {
 		const headerContainer = this.modal.contentEl.createEl("div", {
 			attr: {
-				class: "publish-modal-header-button",
+				class: "publish-modal-header",
 			},
 		});
 
@@ -137,7 +137,7 @@ export class PublishModal {
 				},
 			});
 		[this.deletedContainerCount, this.deletedContainer] =
-			this.createCollapsable("Deleted from vault", {
+			this.createCollapsable("Deleted", {
 				buttonText: "Delete notes from garden",
 				buttonCallback: async () => {
 					const deletedNotes =

--- a/styles.css
+++ b/styles.css
@@ -2,7 +2,6 @@
 
 button:disabled {
 	cursor: not-allowed;
-	color: "#111111";
 }
 
 /* PUBLISH STATUS VIEW */
@@ -15,7 +14,8 @@ button:disabled {
 .digital-garden-publish-status-view ul {
 	list-style-type: none;
 	position: relative;
-	margin-left: 5px;
+	margin-left: 10px;
+	padding: 0;
 	margin-top: 0;
 	overflow: auto;
 }
@@ -30,11 +30,13 @@ button:disabled {
 	margin-left: 10px;
 }
 
-.publish-modal-header-button {
+.publish-modal-header {
 	display: flex;
 	justify-content: space-between;
 	margin-bottom: 10px;
-	align-items: center;
+	line-height: 0px;
+	align-items: baseline;
+	gap: 5px;
 }
 
 .publish-modal-header-content {
@@ -42,13 +44,34 @@ button:disabled {
 	flex-direction: row;
 	align-items: baseline;
 	justify-content: center;
+
+	> h3 {
+		margin-top: 10px;
+		margin-bottom: 5px;
+	}
+}
+
+@media screen and (max-width: 600px) {
+	.publish-modal-header {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+
+		> h3 {
+			margin-top: 10px;
+			margin-bottom: 5px;
+		}
+	}
+
+	.publish-modal-cta-button {
+		margin-left: 20px;
+	}
 }
 
 .publish-modal-change-count {
 	margin-left: 10px;
 }
-
-.dg-settings > h1,
+.setting-item + h1,
 h2,
 h3,
 h4 {

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,22 @@
+/* GENERAL */
+
+button:disabled {
+	cursor: not-allowed;
+	color: "#111111";
+}
+
+/* PUBLISH STATUS VIEW */
+
+.digital-garden-publish-status-view {
+	height: 500px;
+	margin-bottom: 20px;
+}
+
 .digital-garden-publish-status-view ul {
 	list-style-type: none;
 	position: relative;
 	margin-left: 5px;
 	margin-top: 0;
-	max-height: 250px;
 	overflow: auto;
 }
 
@@ -14,6 +27,24 @@
 
 .digital-garden-publish-status-view .collapsable {
 	cursor: pointer;
+	margin-left: 10px;
+}
+
+.publish-modal-header-button {
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: 10px;
+	align-items: center;
+}
+
+.publish-modal-header-content {
+	display: flex;
+	flex-direction: row;
+	align-items: baseline;
+	justify-content: center;
+}
+
+.publish-modal-change-count {
 	margin-left: 10px;
 }
 


### PR DESCRIPTION
The styles were a bit wonky on the publish modal, this moves the styling to styles.css and tries to align stuff on desktop / mobile. 

mostly CSS changes. 

current: 

<img width="314" alt="CleanShot 2023-09-19 at 12 51 03@2x" src="https://github.com/oleeskild/obsidian-digital-garden/assets/4622905/5212e42b-7ae4-4375-b828-2eeb694a8be7">


desktop: 
![CleanShot 2023-09-18 at 17 15 27](https://github.com/oleeskild/obsidian-digital-garden/assets/4622905/982f10c4-76ed-4bae-aea1-e43cec0a4402)

mobile:
![CleanShot 2023-09-19 at 12 54 33](https://github.com/oleeskild/obsidian-digital-garden/assets/4622905/43c60ce9-0a4a-4554-8140-28f91fee361c)
