### PR TITLE
Enhanced publication center UI

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -362,6 +362,7 @@ export default class DigitalGarden extends Plugin {
 				this.app,
 				publishStatusManager,
 				publisher,
+				siteManager,
 				this.settings,
 			);
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"@sindresorhus/slugify": "^1.1.2",
 				"axios": "^1.5.0",
 				"crypto-js": "^4.1.1",
+				"diff": "^5.1.0",
 				"js-base64": "^3.7.5",
 				"luxon": "^3.4.3",
 				"lz-string": "^1.5.0",
@@ -22,6 +23,7 @@
 			"devDependencies": {
 				"@tsconfig/svelte": "^5.0.2",
 				"@types/crypto-js": "^4.1.2",
+				"@types/diff": "^5.0.4",
 				"@types/jest": "^29.5.4",
 				"@types/luxon": "^3.3.2",
 				"@types/node": "^20.6.0",
@@ -1894,6 +1896,12 @@
 			"integrity": "sha512-t33RNmTu5ufG/sorROIafiCVJMx3jz95bXUMoPAZcUD14fxMXnuTzqzXZoxpR0tNx2xpw11Dlmem9vGCsrSOfA==",
 			"dev": true
 		},
+		"node_modules/@types/diff": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.0.4.tgz",
+			"integrity": "sha512-d7489/WO4B65k0SIqxXtviR9+MrPDipWQF6w+5D7YPrqgu6Qb87JsTdWQaNZo7itcdbViQSev3Jaz7dtKO0+Dg==",
+			"dev": true
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
@@ -3269,6 +3277,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/diff": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+			"integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+			"engines": {
+				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/diff-sequences": {
@@ -8594,6 +8610,12 @@
 			"integrity": "sha512-t33RNmTu5ufG/sorROIafiCVJMx3jz95bXUMoPAZcUD14fxMXnuTzqzXZoxpR0tNx2xpw11Dlmem9vGCsrSOfA==",
 			"dev": true
 		},
+		"@types/diff": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.0.4.tgz",
+			"integrity": "sha512-d7489/WO4B65k0SIqxXtviR9+MrPDipWQF6w+5D7YPrqgu6Qb87JsTdWQaNZo7itcdbViQSev3Jaz7dtKO0+Dg==",
+			"dev": true
+		},
 		"@types/estree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
@@ -9571,6 +9593,11 @@
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
+		},
+		"diff": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+			"integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
 		},
 		"diff-sequences": {
 			"version": "29.6.3",

--- a/package.json
+++ b/package.json
@@ -1,64 +1,66 @@
 {
-  "name": "obsidian-garden",
-  "version": "1.0.0",
-  "description": "A plugin used for publishing notes to a digital garden",
-  "main": "main.js",
-  "scripts": {
-    "dev": "node esbuild.config.mjs",
-    "postdev": "copyfiles main.js manifest.json styles.css src/dg-testVault/.obsidian/plugins/obsidian-digital-garden/",
-    "dev1": "parcel main.ts",
-    "build": "node esbuild.config.mjs production",
-    "test": "jest",
-    "prepare": "husky install",
-    "lint": "eslint . --ext .ts",
-    "lint-fix": "eslint .  --fix  --ext .ts",
-    "format": "prettier --write .",
-    "check-formatting": "prettier --check .",
-    "typecheck": "tsc"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
-  "devDependencies": {
-    "@tsconfig/svelte": "^5.0.2",
-    "@types/crypto-js": "^4.1.2",
-    "@types/jest": "^29.5.4",
-    "@types/luxon": "^3.3.2",
-    "@types/node": "^20.6.0",
-    "@typescript-eslint/eslint-plugin": "^6.7.0",
-    "@typescript-eslint/parser": "^6.7.0",
-    "builtin-modules": "^3.3.0",
-    "esbuild": "^0.19.2",
-    "esbuild-svelte": "^0.8.0",
-    "eslint": "^8.49.0",
-    "eslint-plugin-prettier": "^5.0.0",
-    "husky": "^8.0.3",
-    "jest": "^29.7.0",
-    "lint-staged": "^14.0.1",
-    "obsidian": "^1.4.11",
-    "prettier": "3.0.3",
-    "svelte": "^4.2.0",
-    "svelte-preprocess": "^5.0.4",
-    "ts-jest": "^29.1.1",
-    "tslib": "^2.6.2",
-    "typescript": "^5.2.2",
-    "copyfiles": "^2.4.1"
-  },
-  "dependencies": {
-    "@octokit/core": "^5.0.0",
-    "@popperjs/core": "^2.11.8",
-    "@sindresorhus/slugify": "^1.1.2",
-    "axios": "^1.5.0",
-    "crypto-js": "^4.1.1",
-    "js-base64": "^3.7.5",
-    "luxon": "^3.4.3",
-    "lz-string": "^1.5.0",
-    "obsidian-dataview": "^0.5.56"
-  },
-  "lint-staged": {
-    "*.{ts}": [
-      "prettier --write",
-      "eslint --fix ."
-    ]
-  }
+	"name": "obsidian-garden",
+	"version": "1.0.0",
+	"description": "A plugin used for publishing notes to a digital garden",
+	"main": "main.js",
+	"scripts": {
+		"dev": "node esbuild.config.mjs",
+		"postdev": "copyfiles main.js manifest.json styles.css src/dg-testVault/.obsidian/plugins/obsidian-digital-garden/",
+		"dev1": "parcel main.ts",
+		"build": "node esbuild.config.mjs production",
+		"test": "jest",
+		"prepare": "husky install",
+		"lint": "eslint . --ext .ts",
+		"lint-fix": "eslint .  --fix  --ext .ts",
+		"format": "prettier --write .",
+		"check-formatting": "prettier --check .",
+		"typecheck": "tsc"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "MIT",
+	"devDependencies": {
+		"@tsconfig/svelte": "^5.0.2",
+		"@types/crypto-js": "^4.1.2",
+		"@types/diff": "^5.0.4",
+		"@types/jest": "^29.5.4",
+		"@types/luxon": "^3.3.2",
+		"@types/node": "^20.6.0",
+		"@typescript-eslint/eslint-plugin": "^6.7.0",
+		"@typescript-eslint/parser": "^6.7.0",
+		"builtin-modules": "^3.3.0",
+		"copyfiles": "^2.4.1",
+		"esbuild": "^0.19.2",
+		"esbuild-svelte": "^0.8.0",
+		"eslint": "^8.49.0",
+		"eslint-plugin-prettier": "^5.0.0",
+		"husky": "^8.0.3",
+		"jest": "^29.7.0",
+		"lint-staged": "^14.0.1",
+		"obsidian": "^1.4.11",
+		"prettier": "3.0.3",
+		"svelte": "^4.2.0",
+		"svelte-preprocess": "^5.0.4",
+		"ts-jest": "^29.1.1",
+		"tslib": "^2.6.2",
+		"typescript": "^5.2.2"
+	},
+	"dependencies": {
+		"@octokit/core": "^5.0.0",
+		"@popperjs/core": "^2.11.8",
+		"@sindresorhus/slugify": "^1.1.2",
+		"axios": "^1.5.0",
+		"crypto-js": "^4.1.1",
+		"diff": "^5.1.0",
+		"js-base64": "^3.7.5",
+		"luxon": "^3.4.3",
+		"lz-string": "^1.5.0",
+		"obsidian-dataview": "^0.5.56"
+	},
+	"lint-staged": {
+		"*.{ts}": [
+			"prettier --write",
+			"eslint --fix ."
+		]
+	}
 }

--- a/src/models/TreeNode.ts
+++ b/src/models/TreeNode.ts
@@ -1,0 +1,10 @@
+type TreeNode = {
+	name: string;
+	children?: TreeNode[];
+	isRoot: boolean;
+	path: string;
+	checked: boolean;
+	indeterminate: boolean;
+};
+
+export default TreeNode;

--- a/src/publisher/DigitalGardenSiteManager.ts
+++ b/src/publisher/DigitalGardenSiteManager.ts
@@ -132,6 +132,25 @@ export default class DigitalGardenSiteManager {
 		return `${baseUrl}${urlPath}`;
 	}
 
+	async getNoteContent(path: string): Promise<string> {
+		if (path.startsWith("/")) {
+			path = path.substring(1);
+		}
+		const octokit = new Octokit({ auth: this.settings.githubToken });
+		const response = await octokit.request(
+			`GET /repos/{owner}/{repo}/contents/{path}`,
+			{
+				owner: this.settings.githubUserName,
+				repo: this.settings.githubRepo,
+				path: "src/site/notes/" + path,
+			},
+		);
+
+		// @ts-expect-error data is not yet type-guarded
+		const content = Base64.decode(response.data.content);
+		return content;
+	}
+
 	async getNoteHashes(): Promise<Record<string, string>> {
 		const octokit = new Octokit({ auth: this.settings.githubToken });
 		// Force the cache to be updated

--- a/src/ui/DiffView.svelte
+++ b/src/ui/DiffView.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	export let diff: any[];
+</script>
+
+<div>
+    <div class="info callout">
+        Differences between your local file and the published file.
+        <br/>
+        The content may look a bit different from your note. This is because it shows the note after being processed by the plugin.
+    </div>
+    <hr/>
+	{#if diff}
+		<div>
+			{#each diff as part}
+				{#if part.added}
+					<pre
+						style="display: block; background-color: rgba(170, 255, 170, 0.5); color: var(--text-on-accent)"
+						>{part.value}</pre>
+				{:else if part.removed}
+					<pre
+						style="display: block; background-color: rgba(255, 170, 170, 0.5); color: var(--text-on-accent)"
+						>{part.value}</pre>
+				{:else}
+					<pre>{part.value}</pre>
+				{/if}
+			{/each}
+		</div>
+	{/if}
+</div>
+<style>
+    pre {
+        display: block;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+    }
+</style>

--- a/src/ui/PublicationCenter.svelte
+++ b/src/ui/PublicationCenter.svelte
@@ -1,0 +1,333 @@
+<script lang="ts">
+	import { TFile, getIcon } from "obsidian";
+	import TreeNode from "../models/TreeNode";
+	import {
+		IPublishStatusManager,
+		PublishStatus,
+	} from "../publisher/PublishStatusManager";
+	import TreeView from "src/ui/TreeView/TreeView.svelte";
+	import { onMount } from "svelte";
+	import Publisher from "src/publisher/Publisher";
+
+	export let publishStatusManager: IPublishStatusManager;
+	export let publisher: Publisher;
+	export let showDiff: (path: string) => void;
+	export let close: () => void;
+
+	let publishStatus: PublishStatus | undefined;
+	let showPublishingView: boolean = false;
+
+	async function getPublishStatus() {
+		publishStatus = await publishStatusManager.getPublishStatus();
+	}
+
+	onMount(getPublishStatus);
+
+	function insertIntoTree(tree: TreeNode, pathComponents: string[]): void {
+		let currentNode = tree;
+		for (let i = 0; i < pathComponents.length; i++) {
+			const part = pathComponents[i];
+			if (!currentNode.children) {
+				currentNode.children = [];
+			}
+
+			let childNode = currentNode.children.find(
+				(child) => child.name === part
+			);
+
+			if (!childNode) {
+				childNode = {
+					name: part,
+					isRoot: false,
+					path: pathComponents.slice(0, i + 1).join("/"),
+					indeterminate: false,
+					checked: false,
+				};
+				currentNode.children.push(childNode);
+			}
+
+			currentNode = childNode;
+		}
+	}
+
+	function filePathsToTree(
+		filePaths: string[],
+		rootName: string = "root"
+	): TreeNode {
+		const root: TreeNode = {
+			name: rootName,
+			isRoot: true,
+			path: "/",
+			indeterminate: false,
+			checked: false,
+		};
+		for (const filePath of filePaths) {
+			const pathComponents = filePath.split("/");
+			insertIntoTree(root, pathComponents);
+		}
+		return root;
+	}
+
+
+	const rotatingCog = () => {
+		let cog = getIcon("cog");
+		cog?.classList.add("dg-rotate");
+		cog?.style.setProperty("margin-right", "3px");
+		return cog;
+	};
+	const bigRotatingCog = () => {
+		let cog = getIcon("cog");
+		cog?.classList.add("dg-rotate");
+		cog?.style.setProperty("margin-right", "3px");
+		cog?.style.setProperty("width", "40px");
+		cog?.style.setProperty("height", "40px");
+		return cog;
+	};
+
+	$: publishedNotesTree = publishStatus
+		? filePathsToTree(
+				publishStatus.publishedNotes.map((note) => note.path),
+				"Published Notes"
+		  )
+		: null;
+
+	$: changedNotesTree = publishStatus
+		? filePathsToTree(
+				publishStatus.changedNotes.map((note) => note.path),
+				"Changed Notes"
+		  )
+		: null;
+
+	$: deletedNoteTree = publishStatus
+		? filePathsToTree(publishStatus.deletedNotePaths, "Deleted Notes")
+		: null;
+
+	$: unpublishedNoteTree = publishStatus
+		? filePathsToTree(
+				publishStatus.unpublishedNotes.map((note) => note.path),
+				"Unpublished Notes"
+		  )
+		: null;
+
+	$: publishProgress = ((publishedPaths.length + failedPublish.length)/(unpublishedToPublish.length + changedToPublish.length + pathsToDelete.length))*100;
+	const traverseTree = (tree: TreeNode): Array<string> => {
+		const paths: Array<string> = [];
+		if (tree.children) {
+			for (const child of tree.children) {
+				paths.push(...traverseTree(child));
+			}
+		} else {
+			if (tree.checked) {
+				paths.push(tree.path);
+			}
+		}
+		return paths;
+	};
+
+	let unpublishedToPublish: Array<TFile> = [];
+	let changedToPublish: Array<TFile> = [];
+	let pathsToDelete: Array<string> = [];
+
+	let processingPaths: Array<string> = [];
+	let publishedPaths: Array<string> = [];
+	let failedPublish: Array<string> = [];
+
+	const publishMarkedNotes = async () => {
+		if (!unpublishedNoteTree || !changedNotesTree) return;
+
+		const unpublishedPaths = traverseTree(unpublishedNoteTree!);
+		const changedPaths = traverseTree(changedNotesTree!);
+
+		pathsToDelete = traverseTree(deletedNoteTree!);
+
+		unpublishedToPublish =
+			publishStatus?.unpublishedNotes.filter((note) =>
+				unpublishedPaths.includes(note.path)
+			) ?? [];
+
+		changedToPublish =
+			publishStatus?.changedNotes.filter((note) =>
+				changedPaths.includes(note.path)
+			) ?? [];
+
+		showPublishingView = true;
+
+		for (const note of changedToPublish.concat(unpublishedToPublish)) {
+			processingPaths.push(note.path);
+			let isPublished = await publisher.publish(note);
+			processingPaths = processingPaths.filter(
+				(path) => path !== note.path
+			);
+			if(isPublished){
+				publishedPaths = [...publishedPaths, note.path];
+			}else{
+				failedPublish = [...failedPublish, note.path];
+			}
+
+		}
+
+		for (const path of pathsToDelete) {
+			processingPaths.push(path);
+			let isDeleted = await publisher.deleteNote(path);
+			processingPaths = processingPaths.filter((p) => p !== path);
+			if(isDeleted){
+				publishedPaths = [...publishedPaths, path];
+			}
+			else{
+				failedPublish = [...failedPublish, path];
+			}
+		}
+	};
+
+	const emptyNode: TreeNode = {
+		name: "",
+		isRoot: false,
+		path: "",
+		indeterminate: false,
+		checked: false,
+	};
+</script>
+
+<div>
+	<hr class="title-separator" />
+	{#if !publishStatus}
+		<div class="loading-msg">
+			{@html bigRotatingCog()?.outerHTML}
+			<div>Calculating publication status from GitHub</div>
+		</div>
+	{:else if !showPublishingView}
+		<TreeView tree={unpublishedNoteTree ?? emptyNode} {showDiff} />
+
+		<TreeView
+			tree={changedNotesTree ?? emptyNode}
+			{showDiff}
+			enableShowDiff={true}
+		/>
+
+		<TreeView tree={deletedNoteTree ?? emptyNode} {showDiff} />
+
+		<TreeView
+			readOnly={true}
+			tree={publishedNotesTree ?? emptyNode}
+			{showDiff}
+		/>
+
+		<hr class="footer-separator" />
+
+		<div class="footer">
+			<button on:click={publishMarkedNotes}
+				>PUBLISH SELECTED</button
+			>
+		</div>
+	{:else}
+		<div>
+			<div class="callout">
+				<div class="callout-title-inner">
+					Publishing Notes
+				</div>
+				<div>
+					{`${publishedPaths.length} of ${unpublishedToPublish.length + changedToPublish.length + pathsToDelete.length} notes published`} 
+				</div>
+				
+				{#if failedPublish.length > 0}
+				 <div>
+					{`(${failedPublish.length} failed)`}
+				 </div>
+				{/if}
+				<div class="loading-container">
+					<div class="loading-bar" style="width: {publishProgress}%"></div>	
+				</div>
+			</div>
+
+			{#each unpublishedToPublish.concat(changedToPublish) as note}
+				<div class="note-list">
+					{#if processingPaths.includes(note.path)}
+						{@html rotatingCog()?.outerHTML}
+					{:else if publishedPaths.includes(note.path)}
+						{@html getIcon("check")?.outerHTML}
+					{:else if failedPublish.includes(note.path)}
+						{@html getIcon("cross")?.outerHTML}
+					{:else}
+						{@html getIcon("clock")?.outerHTML}
+					{/if}
+					{note.name}
+					{#if publishedPaths.includes(note.path)}
+						<span class="published"> - PUBLISHED</span>
+					{/if}
+				</div>
+			{/each}
+
+			{#each pathsToDelete as path}
+				<div class="note-list">
+					{#if processingPaths.includes(path)}
+						{@html rotatingCog()?.outerHTML}
+					{:else if publishedPaths.includes(path)}
+						{@html getIcon("check")?.outerHTML}
+					{:else}
+						{@html getIcon("clock")?.outerHTML}
+					{/if}
+					{path.split("/").last()}
+
+					{#if publishedPaths.includes(path)}
+						<span class="deleted"> - DELETED</span>
+					{/if}
+				</div>
+			{/each}
+
+			<hr class="footer-separator" />
+
+			<div class="footer">
+				<button on:click={close}
+					>DONE</button
+				>
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.title-separator {
+		margin-top: 0px;
+		margin-bottom: 15px;
+	}
+
+	.footer-separator {
+		margin-top: 15px;
+		margin-bottom: 15px;
+	}
+
+	.footer {
+		display: flex;
+		justify-content: flex-end;
+	}
+
+	.loading-msg {
+		font-size: 1.2rem;
+		display: flex;
+		align-items: center;
+		flex-direction: column;
+	}
+	button {
+		background-color: var(--interactive-accent);
+		color: var(--text-on-accent);
+		cursor: pointer;
+		font-weight: bold;;
+	}
+	.loading-container {
+		width: 100%;
+		height: 5px;
+		margin-top: 10px;
+	}
+
+	.loading-bar{
+		background-color: var(--interactive-accent);
+		height: 100%;
+		transition: all 0.5s ease-in-out;
+	}
+	.published{
+		color: #8bff8b;
+	}
+	.deleted{
+		color: #ff5757;
+	}
+</style>

--- a/src/ui/TreeView/TreeNode.svelte
+++ b/src/ui/TreeView/TreeNode.svelte
@@ -1,0 +1,184 @@
+<script lang="ts" context="module">
+	// retain module scoped expansion state for each tree node
+	export const _expansionState: Record<string, boolean> = {
+		/* treeNodeId: expanded <boolean> */
+	};
+</script>
+
+<!-- TreeView with checkbox https://svelte.dev/repl/eca6f6392e294247b4f379fde3069274?version=3.46.6 -->
+
+<script lang="ts">
+	import { createEventDispatcher } from "svelte";
+	import { getIcon } from "obsidian";
+
+	import TreeNode from "src/models/TreeNode";
+	export let tree: TreeNode;
+	export let readOnly: boolean = false;
+	export let enableShowDiff: boolean = false;
+	const dispatch = createEventDispatcher();
+
+	let { isRoot } = tree;
+
+	let expanded = _expansionState[tree.path] || false;
+	const toggleExpansion = () => {
+		expanded = _expansionState[tree.path] = !expanded;
+	};
+
+	$: arrowDown = expanded;
+
+	const toggleCheck = () => {
+		// update the current node's state here, the UI only need to represent it,
+		// don't need to bind the check state to the UI
+		tree.checked = !tree.checked;
+
+		// emit node 'toggle' event, notify parent compnent to rebuild the entire tree's state
+		dispatch("toggle", {
+			node: tree,
+		});
+	};
+	const dispatchChecked = (e: { detail: { node: TreeNode } }) => {
+		dispatch("toggle", { node: e.detail.node });
+	};
+
+	const showDiff = (e: MouseEvent) => {
+		e.stopPropagation();
+		dispatch("showDiff", { node: tree });
+	};
+
+	const dispatchShowDiff = (node: TreeNode) => {
+		dispatch("showDiff", { node });
+	};
+</script>
+
+<ul class:isRoot>
+	<li>
+		{#if tree.children}
+			<!-- svelte-ignore a11y-click-events-have-key-events -->
+			<!-- svelte-ignore a11y-no-static-element-interactions -->
+			<span>
+				<span on:click={toggleExpansion} class="arrow" class:arrowDown>
+					{@html getIcon("chevron-right")?.outerHTML}
+				</span>
+				{#if !isRoot}
+					{@html getIcon("folder")?.outerHTML}
+					{#if !readOnly}
+						<input
+							type="checkbox"
+							data-label={tree.name}
+							checked={tree.checked}
+							indeterminate={tree.indeterminate}
+							on:click={toggleCheck}
+						/>
+					{/if}
+					{tree.name}
+				{:else}
+					{#if !readOnly}
+						<input
+							type="checkbox"
+							data-label={tree.name}
+							checked={tree.checked}
+							indeterminate={tree.indeterminate}
+							on:click={toggleCheck}
+						/>
+					{/if}
+
+					<span class="root-header">{tree.name}</span>
+				{/if}
+			</span>
+			{#if expanded}
+				{#each tree.children as child}
+					<svelte:self
+						on:toggle={dispatchChecked}
+						on:showDiff={(e) => dispatchShowDiff(e.detail.node)}
+						{enableShowDiff}
+						{readOnly}
+						tree={child}
+					/>
+				{/each}
+			{/if}
+		{:else if !isRoot}
+			<!-- svelte-ignore a11y-no-static-element-interactions -->
+			<span>
+				<span class="no-arrow" />
+				{@html getIcon("file")?.outerHTML}
+				{#if !readOnly}
+					<input
+						type="checkbox"
+						data-label={tree.name}
+						checked={tree.checked}
+						indeterminate={tree.indeterminate}
+						on:click={toggleCheck}
+					/>
+				{/if}
+				{tree.name}
+				<!-- svelte-ignore a11y-click-events-have-key-events -->
+				{#if enableShowDiff}
+					<span title="Show diff" class="diff" on:click={showDiff}>
+						{@html getIcon("file-diff")?.outerHTML}
+					</span>
+				{/if}
+			</span>
+		{/if}
+	</li>
+</ul>
+
+<style>
+	ul {
+		margin: 0;
+		list-style: none;
+		padding-left: 1.2rem;
+		user-select: none;
+	}
+
+	li {
+		margin: 0.2rem 0;
+	}
+
+	.no-arrow {
+		padding-left: calc(var(--icon-size) + 2px);
+	}
+	.arrow {
+		cursor: pointer;
+		display: inline-block;
+		/* transition: transform 200ms; */
+	}
+	.arrowDown {
+		transform: rotate(90deg);
+	}
+	ul.isRoot {
+		padding-left: 0;
+	}
+
+	.root-header {
+		font-weight: bold;
+		font-size: 1.2rem;
+	}
+	input:indeterminate {
+		background-color: var(--checkbox-color);
+		border-color: var(--checkbox-color);
+	}
+	input[type="checkbox"]:indeterminate:after {
+		content: "";
+		top: -1px;
+		left: -1px;
+		position: absolute;
+		width: var(--checkbox-size);
+		height: var(--checkbox-size);
+		display: block;
+		background-color: var(--checkbox-marker-color);
+		-webkit-mask-position: 52% 52%;
+		mask-position: 52% 52%;
+		-webkit-mask-size: 65%;
+		mask-size: 65%;
+		-webkit-mask-repeat: no-repeat;
+		mask-repeat: no-repeat;
+		-webkit-mask-image: url('data:image/svg+xml; utf8,<svg fill="none" width="12px" height="12px" viewBox="0 0 32 32" id="icon" xmlns="http://www.w3.org/2000/svg"><rect fill="%23000000" x="4" y="4" width="24" height="24"/></svg>');
+		mask-image: url('data:image/svg+xml; utf8,<svg fill="none" width="12px" height="12px" viewBox="0 0 32 32" id="icon" xmlns="http://www.w3.org/2000/svg"><rect fill="%23000000" x="4" y="4" width="24" height="24"/></svg>');
+	}
+
+	.diff {
+		cursor: pointer;
+		display: inline-block;
+		margin-left: 4px;
+	}
+</style>

--- a/src/ui/TreeView/TreeView.svelte
+++ b/src/ui/TreeView/TreeView.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import Node from "./TreeNode.svelte";
+	import TreeNode from "src/models/TreeNode";
+	
+	export let tree: TreeNode;
+	export let readOnly: boolean = false;
+	export let enableShowDiff: boolean = false;
+	export let showDiff: (path: string) => void;
+
+
+	const treeMap: Record<string, TreeNode> = {
+		/* child label: parent node */
+	};
+	function initTreeMap(tree:TreeNode) {
+		if (tree.children) {
+			for (const child of tree.children) {
+				treeMap[child.path] = tree;
+				initTreeMap(child);
+			}
+		}
+	};
+	initTreeMap(tree);
+
+	function rebuildChildren(node: TreeNode, checkAsParent = true) {
+		if (node.children) {
+			for (const child of node.children) {
+				if (checkAsParent) child.checked = !!node.checked;
+				rebuildChildren(child, checkAsParent);
+			}
+			node.indeterminate =
+				node.children.some((c) => c.indeterminate) ||
+				(node.children.some((c) => !!c.checked) && node.children.some((c) => !c.checked));
+		}
+	};
+
+	function rebuildTree (e: {detail:{node: TreeNode}}, checkAsParent = true) {
+		const node = e.detail.node;
+		let parent = treeMap[node.path];
+		rebuildChildren(node, checkAsParent);
+		while (parent) {
+			const allCheck = parent?.children?.every((c) => !!c.checked);
+			if (allCheck) {
+				parent.indeterminate = false;
+				parent.checked = true;
+			} else {
+				const haveCheckedOrIndetermine = parent?.children?.some(
+					(c) => !!c.checked || c.indeterminate
+				);
+				if (haveCheckedOrIndetermine) {
+					parent.indeterminate = true;
+				} else {
+					parent.indeterminate = false;
+				}
+				parent.checked = false;
+			}
+
+			parent = treeMap[parent.path];
+		}
+		tree = tree;
+	}
+	// init the tree state
+	rebuildTree({detail: { node: tree }}, false);
+</script>
+
+<div>
+	<Node 
+	{tree} 
+	{readOnly} 
+	{enableShowDiff}
+	on:toggle={rebuildTree} 
+	on:showDiff={(e)=> showDiff(e.detail.node.path)} />
+</div>
+
+<style>
+</style>

--- a/styles.css
+++ b/styles.css
@@ -27,3 +27,17 @@ h4 {
 .dg-settings .svg-icon {
 	margin-right: 10px;
 }
+
+@keyframes dg-rotate {
+	0% {
+		transform: rotate(0deg);
+	}
+
+	100% {
+		transform: rotate(360deg);
+	}
+}
+
+.dg-rotate {
+	animation: dg-rotate 4s linear infinite;
+}


### PR DESCRIPTION
Complete rewrite of the publication center UI. It now features a filetree where the user can select what notes to publish. It also features a diff view, letting users see what changed for "changed notes". 

## Publication status
![CleanShot 2023-09-20 at 21 40 33@2x](https://github.com/oleeskild/obsidian-digital-garden/assets/6201338/7097532a-38ff-439e-9c96-4305a7a80973)
## Diff view
![CleanShot 2023-09-20 at 21 40 51@2x](https://github.com/oleeskild/obsidian-digital-garden/assets/6201338/3d7e4cf5-c1b0-410f-8f90-f905fd91f06a)

## Publishing in progress
![CleanShot 2023-09-20 at 21 41 01@2x](https://github.com/oleeskild/obsidian-digital-garden/assets/6201338/0682a32e-fb9a-4aef-b965-0b4854d45e01)

## Publishing finished
![CleanShot 2023-09-20 at 21 41 03@2x](https://github.com/oleeskild/obsidian-digital-garden/assets/6201338/1e0137fe-e053-47cd-bef0-91773d9130e5)
