### PR TITLE
User friendly settings

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -35,9 +35,9 @@ const DEFAULT_SETTINGS: DigitalGardenSettings = {
 
 	// Timestamp related settings
 	showCreatedTimestamp: false,
-	createdTimestampKey: "dg-created",
+	createdTimestampKey: "",
 	showUpdatedTimestamp: false,
-	updatedTimestampKey: "dg-updated",
+	updatedTimestampKey: "",
 	timestampFormat: "MMM dd, yyyy h:mm a",
 
 	styleSettingsCss: "",

--- a/scripts/generateGardenSettings.mjs
+++ b/scripts/generateGardenSettings.mjs
@@ -26,9 +26,9 @@ const gardenSettings = {
 	showNoteIconOnInternalLink: false,
 	showNoteIconOnBackLink: false,
 	showCreatedTimestamp: false,
-	createdTimestampKey: "dg-created",
+	createdTimestampKey: "",
 	showUpdatedTimestamp: false,
-	updatedTimestampKey: "dg-updated",
+	updatedTimestampKey: "",
 	timestampFormat: "MMM dd, yyyy h:mm a",
 	styleSettingsCss: "",
 	pathRewriteRules: `

--- a/src/test/snapshot/snapshot.md
+++ b/src/test/snapshot/snapshot.md
@@ -1,11 +1,5 @@
 ---
 ---
-{"dg-publish":true,"permalink":"/006-custom-title/","title":"006 THIS IS A CUSTOM TITLE"}
----
-
-[Custom title](https://dg-docs.ole.dev/advanced/note-specific-settings/)
-
----
 {"dg-publish":true,"dg-path":"fun-folder/More specific path rewriting.md","permalink":"/fun-folder/more-specific-path-rewriting/"}
 ---
 
@@ -77,6 +71,12 @@ Hello! I'm a pinned note (should be at the top yeah!)
 
 [Custom permalink](https://dg-docs.ole.dev/advanced/note-specific-settings/)
 
+
+---
+{"dg-publish":true,"permalink":"/006-custom-title/","title":"006 THIS IS A CUSTOM TITLE"}
+---
+
+[Custom title](https://dg-docs.ole.dev/advanced/note-specific-settings/)
 
 ---
 {"dg-publish":true,"permalink":"/005-custom-filters/"}

--- a/src/ui/Icon.svelte
+++ b/src/ui/Icon.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getIcon } from "obsidian";
-    export let name = "";//Lucide icon name. See https://lucide.dev/icons
+	export let name = ""; //Lucide icon name. See https://lucide.dev/icons
 </script>
+
 {@html getIcon(name)?.outerHTML}

--- a/src/ui/Icon.svelte
+++ b/src/ui/Icon.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import { getIcon } from "obsidian";
+    export let name = "";//Lucide icon name. See https://lucide.dev/icons
+</script>
+{@html getIcon(name)?.outerHTML}

--- a/src/ui/PublicationCenter.svelte
+++ b/src/ui/PublicationCenter.svelte
@@ -261,11 +261,11 @@
 					{#if processingPaths.includes(note.path)}
 						{@html rotatingCog()?.outerHTML}
 					{:else if publishedPaths.includes(note.path)}
-					 	<Icon name="check" />
+						<Icon name="check" />
 					{:else if failedPublish.includes(note.path)}
-					 	<Icon name="cross" />
+						<Icon name="cross" />
 					{:else}
-					 	<Icon name="clock" />
+						<Icon name="clock" />
 					{/if}
 					{note.name}
 					{#if publishedPaths.includes(note.path)}
@@ -279,9 +279,9 @@
 					{#if processingPaths.includes(path)}
 						{@html rotatingCog()?.outerHTML}
 					{:else if publishedPaths.includes(path)}
-					 	<Icon name="check" />
+						<Icon name="check" />
 					{:else}
-					 	<Icon name="clock"/>
+						<Icon name="clock" />
 					{/if}
 					{path.split("/").last()}
 

--- a/src/ui/PublicationCenter.svelte
+++ b/src/ui/PublicationCenter.svelte
@@ -8,6 +8,7 @@
 	import TreeView from "src/ui/TreeView/TreeView.svelte";
 	import { onMount } from "svelte";
 	import Publisher from "src/publisher/Publisher";
+	import Icon from "./Icon.svelte";
 
 	export let publishStatusManager: IPublishStatusManager;
 	export let publisher: Publisher;
@@ -260,11 +261,11 @@
 					{#if processingPaths.includes(note.path)}
 						{@html rotatingCog()?.outerHTML}
 					{:else if publishedPaths.includes(note.path)}
-						{@html getIcon("check")?.outerHTML}
+					 	<Icon name="check" />
 					{:else if failedPublish.includes(note.path)}
-						{@html getIcon("cross")?.outerHTML}
+					 	<Icon name="cross" />
 					{:else}
-						{@html getIcon("clock")?.outerHTML}
+					 	<Icon name="clock" />
 					{/if}
 					{note.name}
 					{#if publishedPaths.includes(note.path)}
@@ -278,9 +279,9 @@
 					{#if processingPaths.includes(path)}
 						{@html rotatingCog()?.outerHTML}
 					{:else if publishedPaths.includes(path)}
-						{@html getIcon("check")?.outerHTML}
+					 	<Icon name="check" />
 					{:else}
-						{@html getIcon("clock")?.outerHTML}
+					 	<Icon name="clock"/>
 					{/if}
 					{path.split("/").last()}
 

--- a/src/ui/SettingsView/SettingView.ts
+++ b/src/ui/SettingsView/SettingView.ts
@@ -176,6 +176,8 @@ export default class SettingView {
 						this.settings,
 						this.saveSettings,
 					);
+
+					new Notice("Setting saved");
 				});
 			});
 
@@ -195,6 +197,8 @@ export default class SettingView {
 						this.settings,
 						this.saveSettings,
 					);
+
+					new Notice("Setting saved");
 				});
 			});
 
@@ -214,6 +218,8 @@ export default class SettingView {
 						this.settings,
 						this.saveSettings,
 					);
+
+					new Notice("Setting saved");
 				});
 			});
 
@@ -233,6 +239,8 @@ export default class SettingView {
 						this.settings,
 						this.saveSettings,
 					);
+
+					new Notice("Setting saved");
 				});
 			});
 
@@ -252,6 +260,8 @@ export default class SettingView {
 						this.settings,
 						this.saveSettings,
 					);
+
+					new Notice("Setting saved");
 				});
 			});
 
@@ -269,6 +279,8 @@ export default class SettingView {
 						this.settings,
 						this.saveSettings,
 					);
+
+					new Notice("Setting saved");
 				});
 			});
 
@@ -288,6 +300,8 @@ export default class SettingView {
 						this.settings,
 						this.saveSettings,
 					);
+
+					new Notice("Setting saved");
 				});
 			});
 
@@ -307,6 +321,8 @@ export default class SettingView {
 						this.settings,
 						this.saveSettings,
 					);
+
+					new Notice("Setting saved");
 				});
 			});
 
@@ -326,13 +342,15 @@ export default class SettingView {
 						this.settings,
 						this.saveSettings,
 					);
+
+					new Notice("Setting saved");
 				});
 			});
 
 		new Setting(noteSettingsModal.contentEl)
 			.setName("Let all frontmatter through (dg-pass-frontmatter)")
 			.setDesc(
-				"Determines whether to let all frontmatter data through to the site template. Be aware that this could break your site if you have data in a format not recognized by the template engine, 11ty.",
+				"THIS WILL BREAK YOUR SITE IF YOU DON'T KNOW WHAT YOU ARE DOING! (But disabling will fix it). Determines whether to let all frontmatter data through to the site template. Be aware that this could break your site if you have data in a format not recognized by the template engine, 11ty.",
 			)
 			.addToggle((t) => {
 				t.setValue(this.settings.defaultNoteSettings.dgPassFrontmatter);
@@ -345,6 +363,8 @@ export default class SettingView {
 						this.settings,
 						this.saveSettings,
 					);
+
+					new Notice("Setting saved");
 				});
 			});
 	}
@@ -353,6 +373,21 @@ export default class SettingView {
 		const themeModal = new Modal(this.app);
 		themeModal.containerEl.addClass("dg-settings");
 		themeModal.titleEl.createEl("h1", { text: "Appearance Settings" });
+
+		const handleSaveSettingsButton = (cb: ButtonComponent) => {
+			cb.setButtonText("Apply settings to site");
+			cb.setClass("mod-cta");
+
+			new Notice("Applying settings to site...");
+
+			cb.onClick(async (_ev) => {
+				const octokit = new Octokit({
+					auth: this.settings.githubToken,
+				});
+				await this.saveSettingsAndUpdateEnv();
+				await this.addFavicon(octokit);
+			});
+		};
 
 		new Setting(this.settingsRootElement)
 			.setName("Appearance")
@@ -498,6 +533,8 @@ export default class SettingView {
 				new SvgFileSuggest(this.app, tc.inputEl);
 			});
 
+		new Setting(themeModal.contentEl).addButton(handleSaveSettingsButton);
+
 		themeModal.contentEl
 			.createEl("h2", { text: "Timestamps Settings" })
 			.prepend(this.getIcon("calendar-clock"));
@@ -530,7 +567,7 @@ export default class SettingView {
 		new Setting(themeModal.contentEl)
 			.setName("Created timestamp Frontmatter Key")
 			.setDesc(
-				"Key to get the created timestamp from the frontmatter. Keep blank to get the value from file creation time. The value can be any value that luxon Datetime.fromISO can parse.",
+				"Key to get the created timestamp from the frontmatter. Leave blank to get the value from file creation time. The value can be any value that luxon Datetime.fromISO can parse.",
 			)
 			.addText((text) =>
 				text
@@ -555,7 +592,7 @@ export default class SettingView {
 		new Setting(themeModal.contentEl)
 			.setName("Updated timestamp Frontmatter Key")
 			.setDesc(
-				"Key to get the updated timestamp from the frontmatter. Keep blank to get the value from file update time. The value can be any value that luxon Datetime.fromISO can parse.",
+				"Key to get the updated timestamp from the frontmatter. Leave blank to get the value from file update time. The value can be any value that luxon Datetime.fromISO can parse.",
 			)
 			.addText((text) =>
 				text
@@ -565,6 +602,8 @@ export default class SettingView {
 						await this.saveSettings();
 					}),
 			);
+
+		new Setting(themeModal.contentEl).addButton(handleSaveSettingsButton);
 
 		themeModal.contentEl
 			.createEl("h2", { text: "CSS settings" })
@@ -583,6 +622,8 @@ export default class SettingView {
 						await this.saveSettings();
 					}),
 			);
+
+		new Setting(themeModal.contentEl).addButton(handleSaveSettingsButton);
 
 		themeModal.contentEl
 			.createEl("h2", { text: "Note icons Settings" })
@@ -663,17 +704,7 @@ export default class SettingView {
 				);
 			});
 
-		new Setting(themeModal.contentEl).addButton((cb) => {
-			cb.setButtonText("Apply settings to site");
-
-			cb.onClick(async (_ev) => {
-				const octokit = new Octokit({
-					auth: this.settings.githubToken,
-				});
-				await this.saveSettingsAndUpdateEnv();
-				await this.addFavicon(octokit);
-			});
-		});
+		new Setting(themeModal.contentEl).addButton(handleSaveSettingsButton);
 	}
 
 	private async saveSettingsAndUpdateEnv() {

--- a/src/ui/TreeView/TreeNode.svelte
+++ b/src/ui/TreeView/TreeNode.svelte
@@ -12,6 +12,7 @@
 	import { getIcon } from "obsidian";
 
 	import TreeNode from "src/models/TreeNode";
+	import Icon from "../Icon.svelte";
 	export let tree: TreeNode;
 	export let readOnly: boolean = false;
 	export let enableShowDiff: boolean = false;
@@ -64,10 +65,10 @@
 			<!-- svelte-ignore a11y-no-static-element-interactions -->
 			<span>
 				<span on:click={toggleExpansion} class="arrow" class:arrowDown>
-					{@html getIcon("chevron-right")?.outerHTML}
+					<Icon name="chevron-right" />
 				</span>
 				{#if !isRoot}
-					{@html getIcon("folder")?.outerHTML}
+				 	<Icon name="folder" />
 					{#if !readOnly}
 						<input
 							type="checkbox"
@@ -111,7 +112,7 @@
 			<!-- svelte-ignore a11y-no-static-element-interactions -->
 			<span>
 				<span class="no-arrow" />
-				{@html getIcon("file")?.outerHTML}
+				<Icon name="file" />
 				{#if !readOnly}
 					<input
 						type="checkbox"
@@ -127,7 +128,7 @@
 				<!-- svelte-ignore a11y-click-events-have-key-events -->
 				{#if enableShowDiff}
 					<span title="Show diff" class="diff" on:click={showDiff}>
-						{@html getIcon("file-diff")?.outerHTML}
+						<Icon name="file-diff" />
 					</span>
 				{/if}
 			</span>

--- a/src/ui/TreeView/TreeNode.svelte
+++ b/src/ui/TreeView/TreeNode.svelte
@@ -9,7 +9,6 @@
 
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
-	import { getIcon } from "obsidian";
 
 	import TreeNode from "src/models/TreeNode";
 	import Icon from "../Icon.svelte";
@@ -68,7 +67,7 @@
 					<Icon name="chevron-right" />
 				</span>
 				{#if !isRoot}
-				 	<Icon name="folder" />
+					<Icon name="folder" />
 					{#if !readOnly}
 						<input
 							type="checkbox"


### PR DESCRIPTION
All appearence setting categories now have their own button. This should make it more obvious to users that they need to save it. 

Additionally, since the global note settings are applied right away, we now give feedback in form of a notice that the setting has been applied. 

Lastly the default timestamp key has been left blank, which is probably what most users want. Hopefully this leads to less confusion when wanting to show timestamps.