### PR TITLE
Abstract file into class

### DIFF
--- a/src/compiler/FrontmatterCompiler.ts
+++ b/src/compiler/FrontmatterCompiler.ts
@@ -1,5 +1,5 @@
 import { DateTime } from "luxon";
-import { FrontMatterCache, MetadataCache, TFile, Vault } from "obsidian";
+import { FrontMatterCache, MetadataCache, TFile } from "obsidian";
 import {
 	getGardenPathForNote,
 	sanitizePermalink,
@@ -33,8 +33,7 @@ export class FrontmatterCompiler {
 	private readonly settings: DigitalGardenSettings;
 	private readonly rewriteRules: PathRewriteRules;
 
-	constructor(vault: Vault, settings: DigitalGardenSettings) {
-		// this.vault = vault;
+	constructor(settings: DigitalGardenSettings) {
 		this.settings = settings;
 		this.rewriteRules = getRewriteRules(settings.pathRewriteRules);
 	}

--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -40,6 +40,8 @@ export interface Assets {
 	images: Array<Asset>;
 }
 
+export type TCompiledFile = [string, Assets];
+
 export class GardenPageCompiler {
 	private readonly vault: Vault;
 	private readonly settings: DigitalGardenSettings;
@@ -60,12 +62,12 @@ export class GardenPageCompiler {
 		this.settings = settings;
 		this.metadataCache = metadataCache;
 		this.getFilesMarkedForPublishing = getFilesMarkedForPublishing;
-		this.frontMatterCompiler = new FrontmatterCompiler(vault, settings);
+		this.frontMatterCompiler = new FrontmatterCompiler(settings);
 		this.excalidrawCompiler = new ExcalidrawCompiler(vault);
 		this.rewriteRules = getRewriteRules(this.settings.pathRewriteRules);
 	}
 
-	async generateMarkdown(file: TFile): Promise<[string, Assets]> {
+	async generateMarkdown(file: TFile): Promise<TCompiledFile> {
 		const assets: Assets = { images: [] };
 
 		const processedFrontmatter =
@@ -568,7 +570,7 @@ export class GardenPageCompiler {
 
 						const publishedFilesContainsLinkedFile =
 							publishedFiles.find(
-								(f) => f.path == linkedFile.path,
+								(f) => f.getPath() == linkedFile.path,
 							);
 
 						if (publishedFilesContainsLinkedFile) {

--- a/src/publisher/PublishFile.ts
+++ b/src/publisher/PublishFile.ts
@@ -1,0 +1,101 @@
+import { MetadataCache, TFile, Vault } from "obsidian";
+import {
+	GardenPageCompiler,
+	TCompiledFile,
+} from "../compiler/GardenPageCompiler";
+import {
+	FrontmatterCompiler,
+	TFrontmatter,
+} from "../compiler/FrontmatterCompiler";
+import DigitalGardenSettings from "../models/settings";
+import { isPublishFrontmatterValid } from "./Validator";
+
+interface IPublishFileProps {
+	file: TFile;
+	vault: Vault;
+	compiler: GardenPageCompiler;
+	metadataCache: MetadataCache;
+	settings: DigitalGardenSettings;
+}
+
+export class PublishFile {
+	file: TFile;
+	compiler: GardenPageCompiler;
+	vault: Vault;
+	compiledFile?: TCompiledFile;
+	metadataCache: MetadataCache;
+	frontmatter: TFrontmatter;
+	settings: DigitalGardenSettings;
+
+	constructor({
+		file,
+		compiler,
+		metadataCache,
+		vault,
+		settings,
+	}: IPublishFileProps) {
+		this.compiler = compiler;
+		this.metadataCache = metadataCache;
+		this.file = file;
+		this.settings = settings;
+		this.vault = vault;
+		this.frontmatter = this.getFrontmatter();
+	}
+
+	async compile(): Promise<CompiledPublishFile> {
+		const compiledFile = await this.compiler.generateMarkdown(this.file);
+
+		return new CompiledPublishFile(
+			{
+				file: this.file,
+				compiler: this.compiler,
+				metadataCache: this.metadataCache,
+				vault: this.vault,
+				settings: this.settings,
+			},
+			compiledFile,
+		);
+	}
+
+	shouldPublish(): boolean {
+		return isPublishFrontmatterValid(this.frontmatter);
+	}
+
+	async getImageLinks() {
+		const content = await this.cachedRead();
+
+		return this.compiler.extractImageLinks(content, this.file.path);
+	}
+
+	async cachedRead() {
+		return this.vault.cachedRead(this.file);
+	}
+
+	getFrontmatter() {
+		return this.metadataCache.getCache(this.file.path)?.frontmatter ?? {};
+	}
+
+	getPath = () => this.file.path;
+	getProcessedFrontmatter() {
+		const frontmatterCompiler = new FrontmatterCompiler(this.settings);
+
+		const metadata =
+			this.metadataCache.getCache(this.file.path)?.frontmatter ?? {};
+
+		return frontmatterCompiler.getProcessedFrontMatter(this.file, metadata);
+	}
+}
+
+export class CompiledPublishFile extends PublishFile {
+	compiledFile: TCompiledFile;
+
+	constructor(props: IPublishFileProps, compiledFile: TCompiledFile) {
+		super(props);
+
+		this.compiledFile = compiledFile;
+	}
+
+	getCompiledFile() {
+		return this.compiledFile;
+	}
+}

--- a/src/publisher/Publisher.ts
+++ b/src/publisher/Publisher.ts
@@ -7,7 +7,7 @@ import { PathRewriteRules } from "./DigitalGardenSiteManager";
 import DigitalGardenSettings from "../models/settings";
 import { Assets, GardenPageCompiler } from "../compiler/GardenPageCompiler";
 
-interface MarkedForPublishing {
+export interface MarkedForPublishing {
 	notes: TFile[];
 	images: string[];
 }

--- a/src/publisher/Publisher.ts
+++ b/src/publisher/Publisher.ts
@@ -7,7 +7,7 @@ import { PathRewriteRules } from "./DigitalGardenSiteManager";
 import DigitalGardenSettings from "../models/settings";
 import { Assets, GardenPageCompiler } from "../compiler/GardenPageCompiler";
 
-export interface MarkedForPublishing {
+interface MarkedForPublishing {
 	notes: TFile[];
 	images: string[];
 }

--- a/src/publisher/Publisher.ts
+++ b/src/publisher/Publisher.ts
@@ -40,7 +40,7 @@ export default class Publisher {
 			vault,
 			settings,
 			metadataCache,
-			this.getFilesMarkedForPublishing,
+			() => this.getFilesMarkedForPublishing(),
 		);
 	}
 

--- a/src/publisher/Publisher.ts
+++ b/src/publisher/Publisher.ts
@@ -2,7 +2,7 @@ import { MetadataCache, Notice, TFile, Vault } from "obsidian";
 import { Base64 } from "js-base64";
 import { Octokit } from "@octokit/core";
 import { getRewriteRules } from "../utils/utils";
-import { isPublishFrontmatterValid } from "./Validator";
+import { hasPublishFlag } from "./Validator";
 import { PathRewriteRules } from "./DigitalGardenSiteManager";
 import DigitalGardenSettings from "../models/settings";
 import { Assets, GardenPageCompiler } from "../compiler/GardenPageCompiler";
@@ -47,7 +47,7 @@ export default class Publisher {
 	shouldPublish(file: TFile): boolean {
 		const frontMatter = this.metadataCache.getCache(file.path)?.frontmatter;
 
-		return isPublishFrontmatterValid(frontMatter);
+		return hasPublishFlag(frontMatter);
 	}
 
 	async getFilesMarkedForPublishing(): Promise<MarkedForPublishing> {

--- a/src/publisher/Validator.ts
+++ b/src/publisher/Validator.ts
@@ -1,9 +1,12 @@
 import { FrontMatterCache, Notice } from "obsidian";
 
+export const hasPublishFlag = (frontMatter?: FrontMatterCache): boolean =>
+	!!frontMatter?.["dg-publish"];
+
 export function isPublishFrontmatterValid(
 	frontMatter?: FrontMatterCache,
 ): boolean {
-	if (!frontMatter || !frontMatter["dg-publish"]) {
+	if (!hasPublishFlag(frontMatter)) {
 		new Notice(
 			"Note does not have the dg-publish: true set. Please add this and try again.",
 		);

--- a/src/test/snapshot/generateGardenSnapshot.ts
+++ b/src/test/snapshot/generateGardenSnapshot.ts
@@ -21,18 +21,19 @@ export const generateGardenSnapshot = async (
 	let fileString = "---\n";
 
 	const notesSortedByCreationDate = marked.notes.sort(
-		(note) => note.stat.ctime,
+		(note) => note.file.stat.ctime,
 	);
 
 	const assetPaths = new Set<string>();
 
 	for (const file of notesSortedByCreationDate) {
 		fileString += "==========\n";
-		fileString += `${file.path}\n`;
+		fileString += `${file.getPath()}\n`;
 		fileString += "==========\n";
 
-		const [content, assets] =
-			await publisher.compiler.generateMarkdown(file);
+		const [content, assets] = await publisher.compiler.generateMarkdown(
+			file.file,
+		);
 		assets.images.map((image) => assetPaths.add(image.path));
 
 		fileString += `${content}\n`;


### PR DESCRIPTION
Abstracts file to class, it can compile itself and return things. 

Ideally it would handle it's own metadata too, and the compiler could be less complex. 

Then we can do 

`type TCompiler = (PublishFile) => string`

and inside a compiler: 

```ts
const icon = publishFile.meta.getIcon 
```

instead of stuff like this: 

```ts
		const noteIconKey = this.settings.noteIconKey;

		if (baseFrontMatter[noteIconKey] !== undefined) {
			publishedFrontMatter["noteIcon"] = baseFrontMatter[noteIconKey];
		} else {
			publishedFrontMatter["noteIcon"] = this.settings.defaultNoteIcon;
		}
```

It COULD be that we'd want PublishFile to extend TFile. Also not 100% on the name PublishFile. 