### PR TITLE
Version/2.55.0

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -41,6 +41,7 @@ const DEFAULT_SETTINGS: DigitalGardenSettings = {
 	timestampFormat: "MMM dd, yyyy h:mm a",
 
 	styleSettingsCss: "",
+	styleSettingsBodyClasses: "",
 	pathRewriteRules: "",
 	customFilters: [],
 

--- a/scripts/generateGardenSettings.mjs
+++ b/scripts/generateGardenSettings.mjs
@@ -33,6 +33,7 @@ const gardenSettings = {
 	updatedTimestampKey: "customUpdated",
 	timestampFormat: "MMM dd, yyyy h:mm a",
 	styleSettingsCss: "",
+	styleSettingsBodyClasses: "",
 	pathRewriteRules: `
 Path Rewriting/Subfolder2:fun-folder
 Path Rewriting:

--- a/src/compiler/DataviewCompiler.ts
+++ b/src/compiler/DataviewCompiler.ts
@@ -117,14 +117,12 @@ export class DataviewCompiler {
 				const query = inlineQuery[1];
 
 				const dataviewResult = dvApi.tryEvaluate(query.trim(), {
-					// @ts-expect-error errors are caught
 					this: dvApi.page(file.getPath()),
 				});
 
 				if (dataviewResult) {
 					replacedText = replacedText.replace(
 						code,
-						// @ts-expect-error errors are caught
 						dataviewResult.toString(),
 					);
 				}
@@ -228,7 +226,6 @@ function tryDVEvaluate(
 
 	try {
 		const dataviewResult = dvApi.tryEvaluate(query.trim(), {
-			// @ts-expect-error errors are caught
 			this: dvApi.page(file.getPath()),
 		});
 		result = dataviewResult?.toString() ?? "";

--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -521,6 +521,11 @@ export class GardenPageCompiler {
 					if (svgText && size) {
 						svgText = setWidth(svgText, size);
 					}
+
+					if (svgText) {
+						//Remove whitespace, as markdown-it will insert a <p> tag otherwise
+						svgText = svgText.replace(/[\t\n\r]/g, "");
+					}
 					text = text.replace(svg, svgText);
 				} catch {
 					continue;

--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -676,11 +676,16 @@ export class GardenPageCompiler {
 
 						const lastValue =
 							metaDataAndSize[metaDataAndSize.length - 1];
-						const lastValueIsSize = !isNaN(parseInt(lastValue));
 
-						const lastValueIsMetaData = !lastValueIsSize;
+						const hasSeveralValues = metaDataAndSize.length > 0;
 
-						const size = lastValueIsSize ? lastValue : undefined;
+						const lastValueIsSize =
+							hasSeveralValues && !isNaN(parseInt(lastValue));
+
+						const lastValueIsMetaData =
+							!lastValueIsSize && hasSeveralValues;
+
+						const size = lastValueIsSize ? lastValue : null;
 
 						let metaData = "";
 
@@ -720,7 +725,7 @@ export class GardenPageCompiler {
 							name = `${imageName}|${metaData}|${size}`;
 						} else if (size) {
 							name = `${imageName}|${size}`;
-						} else if (metaData) {
+						} else if (metaData && metaData !== "") {
 							name = `${imageName}|${metaData}`;
 						} else {
 							name = imageName;

--- a/src/dg-testVault/L Links/01 Link to header.md
+++ b/src/dg-testVault/L Links/01 Link to header.md
@@ -1,0 +1,5 @@
+---
+dg-publish: true
+---
+Link to header should keep header link info
+[[000 Home#Welcome]]

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -35,6 +35,8 @@ export default interface DigitalGardenSettings {
 	timestampFormat: string;
 
 	styleSettingsCss: string;
+	styleSettingsBodyClasses: string;
+
 	pathRewriteRules: string;
 	customFilters: Array<{ pattern: string; flags: string; replace: string }>;
 	contentClassesKey: string;

--- a/src/repositoryConnection/DigitalGardenSiteManager.ts
+++ b/src/repositoryConnection/DigitalGardenSiteManager.ts
@@ -96,6 +96,7 @@ export default class DigitalGardenSiteManager {
 			NOTE_ICON_INTERNAL_LINKS: this.settings.showNoteIconOnInternalLink,
 			NOTE_ICON_BACK_LINKS: this.settings.showNoteIconOnBackLink,
 			STYLE_SETTINGS_CSS: this.settings.styleSettingsCss,
+			STYLE_SETTINGS_BODY_CLASSES: this.settings.styleSettingsBodyClasses,
 		} as Record<string, string | boolean>;
 
 		if (theme.name !== "default") {

--- a/src/test/snapshot/snapshot.md
+++ b/src/test/snapshot/snapshot.md
@@ -345,7 +345,7 @@ E Embeds/E02 PNG published.md
 
 
 
-![travolta.png| undefined](/img/user/A%20Assets/travolta.png)
+![travolta.png](/img/user/A%20Assets/travolta.png)
 /img/user/A Assets/travolta.png
 ==========
 E Embeds/E04 PNG reuse.md
@@ -367,7 +367,7 @@ E Embeds/E05 WEBP published.md
 ---
 
 
-![travolta.webp| undefined](/img/user/A%20Assets/travolta.webp)
+![travolta.webp](/img/user/A%20Assets/travolta.webp)
 /img/user/A Assets/travolta.png
 ,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
@@ -385,7 +385,7 @@ Like so: `![travolta.png|center|200](/img/user/A%20Assets/travolta.png)`
 
 This should render to an image with the alt text "left", like so:
 `[travolta.png|left](/img/user/A%20Assets/travolta.png)`
-![travolta.png| left](/img/user/A%20Assets/travolta.png)
+![travolta.png|left](/img/user/A%20Assets/travolta.png)
 /img/user/A Assets/travolta.png
 ,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
@@ -612,6 +612,18 @@ this plugin has custom filter that turns 🌞 (snow emoji) into 🌞 (THE SUN). 
 ,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
 ==========
+L Links/01 Link to header.md
+==========
+---
+{"dg-publish":true,"permalink":"/l-links/01-link-to-header/"}
+---
+
+Link to header should keep header link info
+[[000 Home#Welcome\|000 Home#Welcome]]
+/img/user/A Assets/travolta.png
+,/img/user/A Assets/unused_image.png
+,/img/user/A Assets/travolta.webp
+==========
 P Plugins/PD Dataview/PD1 Dataview.md
 ==========
 ---
@@ -658,7 +670,7 @@ P Plugins/PD Dataview/PD3 Inline JS queries.md
 
 
 3
-94
+96
 <p><span>A paragraph</span></p>
 
 /img/user/A Assets/travolta.png

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -81,7 +81,7 @@ function getGardenPathForNote(
 	rules: PathRewriteRules,
 ): string {
 	for (const { from, to } of rules) {
-		if (vaultPath.startsWith(from)) {
+		if (vaultPath && vaultPath.startsWith(from)) {
 			const newPath = vaultPath.replace(from, to);
 
 			// remote leading slash if to = ""

--- a/src/views/SettingsView/RewriteSettings.svelte
+++ b/src/views/SettingsView/RewriteSettings.svelte
@@ -39,9 +39,9 @@
 		const files = await publisher.getFilesMarkedForPublishing();
 
 		const paths = files.notes.map((note) => ({
-			id: note.path,
-			newPath: getGardenPathForNote(note.path, newRewriteRules),
-			oldPath: getGardenPathForNote(note.path, oldRewriteRules),
+			id: note.file.path,
+			newPath: getGardenPathForNote(note.file.path, newRewriteRules),
+			oldPath: getGardenPathForNote(note.file.path, oldRewriteRules),
 		}));
 
 		return paths;

--- a/src/views/SettingsView/SettingView.ts
+++ b/src/views/SettingsView/SettingView.ts
@@ -412,27 +412,54 @@ export default class SettingView {
 								"#css-settings-manager",
 							);
 
-							if (!styleSettingsNode) {
+							const bodyClasses =
+								document.querySelector("body")?.className;
+
+							if (!styleSettingsNode && !bodyClasses) {
 								new Notice("No Style Settings found");
 
 								return;
 							}
 
-							this.settings.styleSettingsCss =
-								styleSettingsNode.innerHTML;
+							if (styleSettingsNode?.innerHTML) {
+								this.settings.styleSettingsCss =
+									styleSettingsNode?.innerHTML;
+							}
 
-							if (!this.settings.styleSettingsCss) {
+							if (bodyClasses) {
+								this.settings.styleSettingsBodyClasses = `${bodyClasses}`;
+							}
+
+							if (
+								!this.settings.styleSettingsCss &&
+								!this.settings.styleSettingsBodyClasses
+							) {
 								new Notice("No Style Settings found");
 
 								return;
 							}
 
-							this.saveSiteSettingsAndUpdateEnv(
+							await this.saveSiteSettingsAndUpdateEnv(
 								this.app.metadataCache,
 								this.settings,
 								this.saveSettings,
 							);
 							new Notice("Style Settings applied to site");
+						});
+					})
+					.addButton((btn) => {
+						btn.setButtonText("Clear");
+
+						btn.onClick(async (_ev) => {
+							this.settings.styleSettingsCss = "";
+							this.settings.styleSettingsBodyClasses = "";
+
+							await this.saveSiteSettingsAndUpdateEnv(
+								this.app.metadataCache,
+								this.settings,
+								this.saveSettings,
+							);
+							new Notice("Style Settings removed from site");
 						});
 					});
 			}


### PR DESCRIPTION
- Fixes some SVGs messing up the entire page if they contained any whitespace in between the tags.
- Adds support for setting body classes, which will make the style setting support behave more as expected.
- Fixes a bug where the path rewrite live change preview would never work