### PR TITLE
fix document rendered repeatedly bug

### DIFF
--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -247,7 +247,10 @@ export class GardenPageCompiler {
 							headerSplit.length > 1 ? `#${headerSplit[1]}` : "";
 					}
 					const fullLinkedFilePath = getLinkpath(linkedFileName);
-
+					
+					if (fullLinkedFilePath === "") {
+						continue;
+					}
 					const linkedFile = this.metadataCache.getFirstLinkpathDest(
 						fullLinkedFilePath,
 						file.getPath(),
@@ -310,7 +313,10 @@ export class GardenPageCompiler {
 
 					const transclusionFilePath =
 						getLinkpath(transclusionFileName);
-
+					
+					if (transclusionFilePath === "") {
+						continue;
+					}
 					const linkedFile = this.metadataCache.getFirstLinkpathDest(
 						transclusionFilePath,
 						file.getPath(),
@@ -511,7 +517,10 @@ export class GardenPageCompiler {
 						.substring(svg.indexOf("[") + 2, svg.indexOf("]"))
 						.split("|");
 					const imagePath = getLinkpath(imageName);
-
+					
+					if (imagePath === "") {
+						continue;
+					}
 					const linkedFile = this.metadataCache.getFirstLinkpathDest(
 						imagePath,
 						file.getPath(),
@@ -556,6 +565,9 @@ export class GardenPageCompiler {
 						continue;
 					}
 
+					if (imagePath === "") {
+						continue;
+					}
 					const linkedFile = this.metadataCache.getFirstLinkpathDest(
 						imagePath,
 						file.getPath(),
@@ -602,6 +614,9 @@ export class GardenPageCompiler {
 						.split("|");
 					const imagePath = getLinkpath(imageName);
 
+					if (imagePath === "") {
+						continue;
+					}
 					const linkedFile = this.metadataCache.getFirstLinkpathDest(
 						imagePath,
 						file.getPath(),
@@ -637,6 +652,9 @@ export class GardenPageCompiler {
 
 					const decodedImagePath = decodeURI(imagePath);
 
+					if (decodedImagePath === "") {
+						continue;
+					}
 					const linkedFile = this.metadataCache.getFirstLinkpathDest(
 						decodedImagePath,
 						file.getPath(),
@@ -716,6 +734,9 @@ export class GardenPageCompiler {
 
 						const imagePath = getLinkpath(imageName);
 
+						if (imagePath === "") {
+							continue;
+						}
 						const linkedFile =
 							this.metadataCache.getFirstLinkpathDest(
 								imagePath,
@@ -789,6 +810,9 @@ export class GardenPageCompiler {
 
 						const decodedImagePath = decodeURI(imagePath);
 
+						if (decodedImagePath === "") {
+							continue;
+						}
 						const linkedFile =
 							this.metadataCache.getFirstLinkpathDest(
 								decodedImagePath,


### PR DESCRIPTION
When "`![[]]`或者`[[]]`" exists in markdown, the document is rendered repeatedly, because if the path passed to the getFirstLinkpathDest function is an empty string, the current document is returned.