### PR TITLE
fix: link to fine-grained token docs in settings view

### DIFF
--- a/src/views/SettingsView/GithubSettings.ts
+++ b/src/views/SettingsView/GithubSettings.ts
@@ -123,11 +123,11 @@ export class GithubSettings {
 
 		desc.createEl("span", undefined, (span) => {
 			span.innerText =
-				"A GitHub token with repo permissions. You can generate it ";
+				"A GitHub token with contents permissions. You can see how to generate it ";
 
 			span.createEl("a", undefined, (link) => {
 				link.href =
-					"https://github.com/settings/tokens/new?scopes=repo";
+					"https://dg-docs.ole.dev/advanced/fine-grained-access-token/";
 				link.innerText = "here!";
 			});
 		});


### PR DESCRIPTION
The README recommends fine-grained tokens since #489, so the settings view should match