### PR TITLE
Update FrontmatterCompiler.ts

### DIFF
--- a/src/compiler/FrontmatterCompiler.ts
+++ b/src/compiler/FrontmatterCompiler.ts
@@ -166,7 +166,7 @@ export class FrontmatterCompiler {
 					? fileFrontMatter["tags"].split(/,\s*/)
 					: fileFrontMatter["tags"]) || [];
 
-			if (fileFrontMatter["dg-home"]) {
+			if (fileFrontMatter["dg-home"] && !tags.contains("gardenEntry")) {
 				tags.push("gardenEntry");
 			}
 


### PR DESCRIPTION
Fixed the issue where it would infinitely add the "gardenEntry" tag to the tags of the homepage