### PR TITLE
fix: don't replace block IDs in codeblocks

### DIFF
--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -30,6 +30,7 @@ import {
 import Logger from "js-logger";
 import { DataviewCompiler } from "./DataviewCompiler";
 import { PublishFile } from "../publishFile/PublishFile";
+import { replaceBlockIDs } from "./replaceBlockIDs";
 
 export interface Asset {
 	path: string;
@@ -144,21 +145,7 @@ export class GardenPageCompiler {
 	};
 
 	createBlockIDs: TCompilerStep = () => (text: string) => {
-		const block_pattern = / \^([\w\d-]+)/g;
-		const complex_block_pattern = /\n\^([\w\d-]+)\n/g;
-
-		text = text.replace(
-			complex_block_pattern,
-			(_match: string, $1: string) => {
-				return `{ #${$1}}\n\n`;
-			},
-		);
-
-		text = text.replace(block_pattern, (match: string, $1: string) => {
-			return `\n{ #${$1}}\n`;
-		});
-
-		return text;
+		return replaceBlockIDs(text);
 	};
 
 	removeObsidianComments: TCompilerStep = () => (text) => {

--- a/src/compiler/createBlockIDs.test.ts
+++ b/src/compiler/createBlockIDs.test.ts
@@ -1,0 +1,69 @@
+import { replaceBlockIDs } from "./replaceBlockIDs";
+
+describe("replaceBlockIDs", () => {
+	it("should replace block IDs in markdown", () => {
+		const EXPECTED_MARKDOWN = `
+			# header
+
+			foo ^block-id-1234
+
+			bar ^block-id-5678
+
+			below
+			^block-id-9999
+		`;
+
+		const result = replaceBlockIDs(EXPECTED_MARKDOWN);
+
+		expect(result).toBe(`
+			# header
+
+			foo
+			{ #block-id-1234}
+
+			bar
+			{ #block-id-5678}
+
+			below
+			{ #block-id-9999}
+		`);
+	});
+
+	it("should not replace block IDs in code blocks", () => {
+		const CODEBLOCK_WITH_BLOCKIDS = `
+\`\`\`
+foobar.
+this is a code block.
+but it contains a block ID to try to fool the compiler
+and, consequently, wreck your garden.
+here it goes: ^block-id-1234
+and for fun, here's another: ^block-id-5678
+\`\`\`
+
+additionally, block IDs outside of code blocks should be replaced
+for example, ^block-id-9999
+and ^block-id-0000
+		`;
+
+		const result = replaceBlockIDs(CODEBLOCK_WITH_BLOCKIDS);
+
+		expect(result).toBe(`
+\`\`\`
+foobar.
+this is a code block.
+but it contains a block ID to try to fool the compiler
+and, consequently, wreck your garden.
+here it goes: ^block-id-1234
+and for fun, here's another: ^block-id-5678
+\`\`\`
+
+additionally, block IDs outside of code blocks should be replaced
+for example,
+{ #block-id-9999}
+
+and
+{ #block-id-0000}
+
+		`);
+	});
+});

--- a/src/compiler/createBlockIDs.test.ts
+++ b/src/compiler/createBlockIDs.test.ts
@@ -8,9 +8,6 @@ describe("replaceBlockIDs", () => {
 			foo ^block-id-1234
 
 			bar ^block-id-5678
-
-			below
-			^block-id-9999
 		`;
 
 		const result = replaceBlockIDs(EXPECTED_MARKDOWN);
@@ -19,13 +16,12 @@ describe("replaceBlockIDs", () => {
 			# header
 
 			foo
-			{ #block-id-1234}
+{ #block-id-1234}
+
 
 			bar
-			{ #block-id-5678}
+{ #block-id-5678}
 
-			below
-			{ #block-id-9999}
 		`);
 	});
 

--- a/src/compiler/replaceBlockIDs.ts
+++ b/src/compiler/replaceBlockIDs.ts
@@ -1,0 +1,35 @@
+export function replaceBlockIDs(markdown: string) {
+	const block_pattern = / \^([\w\d-]+)/g;
+	const complex_block_pattern = /\n\^([\w\d-]+)\n/g;
+
+	// To ensure code blocks are not modified...
+	const codeBlockPattern = /```[\s\S]*?```/g;
+
+	// Extract code blocks and replace them with placeholders
+	const codeBlocks: string[] = [];
+
+	markdown = markdown.replace(codeBlockPattern, (match) => {
+		codeBlocks.push(match);
+
+		return `{{CODE_BLOCK_${codeBlocks.length - 1}}}`;
+	});
+
+	// Replace patterns outside code blocks
+	markdown = markdown.replace(
+		complex_block_pattern,
+		(_match: string, $1: string) => {
+			return `{ #${$1}}\n\n`;
+		},
+	);
+
+	markdown = markdown.replace(block_pattern, (_match: string, $1: string) => {
+		return `\n{ #${$1}}\n`;
+	});
+
+	// Reinsert code blocks
+	codeBlocks.forEach((block, index) => {
+		markdown = markdown.replace(`{{CODE_BLOCK_${index}}}`, block);
+	});
+
+	return markdown;
+}

--- a/src/dg-testVault/015 Code blocks.md
+++ b/src/dg-testVault/015 Code blocks.md
@@ -1,0 +1,23 @@
+---
+dg-publish: true
+---
+These codeblocks should not be modified upon publish.
+
+Sample 1
+```jinja2
+{{ highlight_text }}{% if highlight_location and highlight_location_url %} ([via]({{highlight_location_url}})){% elif highlight_location %} ({{highlight_location}}){% endif %} ^rwhi{{highlight_id}}
+{% if highlight_note %}
+{{ highlight_note }} ^rwhi{{highlight_id}}_note
+{% endif %}
+```
+
+Sample 2
+```md
+In medieval Latin a florilegium (plural florilegia) was a compilation of excerpts from other writings.
+ The word is from the Latin flos (flower) and legere (to gather): literally a gathering of flowers, or collection of fine extracts from the body of a larger work. ([via](https://en.wikipedia.org/wiki/Florilegium)) ^rwhi724352030
+```
+
+And for sanity, here's some block references outside of code blocks:
+foobar ^test-123
+and another below
+^test-456

--- a/src/dg-testVault/015 Code blocks.md
+++ b/src/dg-testVault/015 Code blocks.md
@@ -7,7 +7,7 @@ Sample 1
 ```jinja2
 {{ highlight_text }}{% if highlight_location and highlight_location_url %} ([via]({{highlight_location_url}})){% elif highlight_location %} ({{highlight_location}}){% endif %} ^rwhi{{highlight_id}}
 {% if highlight_note %}
-{{ highlight_note }} ^rwhi{{highlight_id}}_note
+{{ highlight_note }} ^rwhi{{highlight_id}}-note
 {% endif %}
 ```
 
@@ -17,7 +17,10 @@ In medieval Latin a florilegium (plural florilegia) was a compilation of excerpt
  The word is from the Latin flos (flower) and legere (to gather): literally a gathering of flowers, or collection of fine extracts from the body of a larger work. ([via](https://en.wikipedia.org/wiki/Florilegium)) ^rwhi724352030
 ```
 
-And for sanity, here's some block references outside of code blocks:
-foobar ^test-123
-and another below
-^test-456
+Sample 3
+```
+This codeblock has a transclusion syntax in it.
+Check it out: ![[001 Links]]
+```
+
+And for sanity, here's some block references outside of code blocks: foobar ^test-123

--- a/src/test/snapshot/snapshot.md
+++ b/src/test/snapshot/snapshot.md
@@ -344,6 +344,55 @@ this is just text i guess
 
 
 ==========
+015 Code blocks.md
+==========
+---
+{"dg-publish":true,"permalink":"/015-code-blocks/"}
+---
+
+These codeblocks should not be modified upon publish.
+
+Sample 1
+```jinja2
+{{ highlight_text }}{% if highlight_location and highlight_location_url %} ([via]({{highlight_location_url}})){% elif highlight_location %} ({{highlight_location}}){% endif %} ^rwhi{{highlight_id}}
+{% if highlight_note %}
+{{ highlight_note }} ^rwhi{{highlight_id}}-note
+{% endif %}
+```
+
+Sample 2
+```md
+In medieval Latin a florilegium (plural florilegia) was a compilation of excerpts from other writings.
+ The word is from the Latin flos (flower) and legere (to gather): literally a gathering of flowers, or collection of fine extracts from the body of a larger work. ([via](https://en.wikipedia.org/wiki/Florilegium)) ^rwhi724352030
+```
+
+Sample 3
+```
+This codeblock has a transclusion syntax in it.
+Check it out: 
+<div class="transclusion internal-embed is-loaded"><a class="markdown-embed-link" href="/001-links/" aria-label="Open link"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg></a><div class="markdown-embed">
+
+
+
+
+[[002 Hidden page]]
+
+[[003 Non published page]]
+
+[[000 Home| Aliased link to home]]
+
+[[000 Home | Link containing whitespace which works in obsidian but doesn't in garden :) - yes, this could be a ticket but lo and behold]]
+
+
+
+</div></div>
+
+```
+
+And for sanity, here's some block references outside of code blocks: foobar
+{ #test-123}
+
+==========
 E Embeds/E02 PNG published.md
 ==========
 ---
@@ -715,7 +764,7 @@ P Plugins/PD Dataview/PD3 Inline JS queries.md
 
 
 3
-106
+108
 <p><span>A paragraph</span></p>
 
 /img/user/A Assets/travolta.png


### PR DESCRIPTION
Fixes #595 (which i reported)

The title of this PR is a little too narrow compared to what this PR actually does (~~preserves code blocks~~ actually not quite, see #599), but I wanted to match [the issue](https://github.com/oleeskild/obsidian-digital-garden/issues/595) that I'd opened.

Took a quick stab at *not* replacing `^block-ids` within markdown codeblocks.

Overview of the changes:
- Added a new note: `src/dg-testVault/015 Code blocks.md`
- Pulled the replacement operation out of `createBlockIDs` into its own file/function (`replaceBlockIDs`) so it could be tested independently of the compiler
- Added a test for the new `replaceBlockIDs` fn

The actual mechanism for preserving block IDs within codeblocks is pretty simplistic:
1. Extract and replace code blocks with placeholders: the `text.replace` function collects the code blocks into an array and replaces them with unique placeholders.
1. Process text outside code blocks: the text is processed for block patterns as before.
1. Reinsert code blocks: the placeholders are replaced back with the original code blocks from the array.

I probably didn't do something quite how you would have - let me know what the delta is and I'm happy to address it :cowboy_hat_face: For example: I suspect that a new snapshot is probably recommended, but I'd like some guidance on performing that new snapshot.

I'm very motivated to get this fixed as it is affecting my published notes ([for example](https://notes.tyler.earth/readwise/readwise-to-obsidian-exports-settings/)).