### PR TITLE
Fix duplicated tag 'gardenEntry'

### DIFF
--- a/src/compiler/FrontmatterCompiler.ts
+++ b/src/compiler/FrontmatterCompiler.ts
@@ -166,7 +166,7 @@ export class FrontmatterCompiler {
 					? fileFrontMatter["tags"].split(/,\s*/)
 					: fileFrontMatter["tags"]) || [];
 
-			if (fileFrontMatter["dg-home"]) {
+			if (fileFrontMatter["dg-home"] && !tags.contains("gardenEntry")) {
 				tags.push("gardenEntry");
 			}
 


### PR DESCRIPTION
On notes that are marked as home a tag `gardenEntry` gets added. Because the method can get executed multiple times, it could happen, that the tag was added multiple times.