### PR TITLE
Find CRLF line endings (Windows) with regexes

### DIFF
--- a/src/compiler/replaceBlockIDs.ts
+++ b/src/compiler/replaceBlockIDs.ts
@@ -1,6 +1,6 @@
 export function replaceBlockIDs(markdown: string) {
 	const block_pattern = / \^([\w\d-]+)/g;
-	const complex_block_pattern = /\n\^([\w\d-]+)\n/g;
+	const complex_block_pattern = /[\r\n]\^([\w\d-]+)[\r\n]/g;
 
 	// To ensure code blocks are not modified...
 	const codeBlockPattern = /```[\s\S]*?```/g;

--- a/src/publishFile/ObsidianFrontMatterEngine.ts
+++ b/src/publishFile/ObsidianFrontMatterEngine.ts
@@ -1,4 +1,5 @@
 import { MetadataCache, TFile, Vault } from "obsidian";
+import { FRONTMATTER_REGEX } from "../utils/regexes";
 
 export interface IFrontMatterEngine {
 	set(key: string, value: string | boolean | number): IFrontMatterEngine;
@@ -43,12 +44,11 @@ export default class ObsidianFrontMatterEngine implements IFrontMatterEngine {
 		const newFrontMatter = this.getFrontMatterSnapshot();
 
 		const content = await this.vault.cachedRead(this.file);
-		const frontmatterRegex = /^\s*?---\n([\s\S]*?)\n---/g;
 		const yaml = this.frontMatterToYaml(newFrontMatter);
 		let newContent = "";
 
-		if (content.match(frontmatterRegex)) {
-			newContent = content.replace(frontmatterRegex, (_match) => {
+		if (content.match(FRONTMATTER_REGEX)) {
+			newContent = content.replace(FRONTMATTER_REGEX, (_match) => {
 				return yaml;
 			});
 		} else {

--- a/src/utils/regexes.ts
+++ b/src/utils/regexes.ts
@@ -1,9 +1,9 @@
-export const FRONTMATTER_REGEX = /^\s*?---\n([\s\S]*?)\n---/g;
-export const BLOCKREF_REGEX = /(\^\w+(\n|$))/g;
+export const FRONTMATTER_REGEX = /^\s*?---[\r\n]([\s\S]*?)[\r\n]---/g;
+export const BLOCKREF_REGEX = /(\^\w+([\r\n]|$))/g;
 
 export const CODE_FENCE_REGEX = /`(.*?)`/g;
 
-export const CODEBLOCK_REGEX = /```.*?\n[\s\S]+?```/g;
+export const CODEBLOCK_REGEX = /```.*?[\r\n][\s\S]+?```/g;
 
 export const EXCALIDRAW_REGEX = /:\[\[(\d*?,\d*?)\],.*?\]\]/g;
 


### PR DESCRIPTION
Some of the used regex definitions only looked for `\n` (LF) and not for `\r\n` (CRLF). Because I'm using Windows and sometimes modify files with other editors it can happen that files are saved with CRLF line endings .

This PR changes the regexes that they find both, LF and CRLF.

Fixes #615