### PR TITLE
[BUGFIX] Embeded file link doesn't respect slugifyEnabled

### DIFF
--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -447,6 +447,7 @@ export class GardenPageCompiler {
 											linkedFile.path,
 											this.rewriteRules,
 										),
+										this.settings.slugifyEnabled,
 								  )}`;
 							embedded_link = `<a class="markdown-embed-link" href="${gardenPath}${sectionID}" aria-label="Open link"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg></a>`;
 						}


### PR DESCRIPTION
Possibly related: [https://github.com/oleeskild/obsidian-digital-garden/issues/637](https://github.com/oleeskild/obsidian-digital-garden/issues/637)

I have found out that in my own vault, when embedding another note with the ![[note]] syntax, the `markdown-embed-link` button did not have the correct link.

![image](https://github.com/user-attachments/assets/e82d67ec-ddad-417a-8d5c-789b82af9b19)

![image](https://github.com/user-attachments/assets/891b093e-5027-45d8-a372-278bebdf0e29)

This PR fixes that.