### PR TITLE
PDF Extension

### DIFF
--- a/src/utils/regexes.ts
+++ b/src/utils/regexes.ts
@@ -9,3 +9,7 @@ export const EXCALIDRAW_REGEX = /:\[\[(\d*?,\d*?)\],.*?\]\]/g;
 
 export const TRANSCLUDED_SVG_REGEX =
 	/!\[\[(.*?)(\.(svg))\|(.*?)\]\]|!\[\[(.*?)(\.(svg))\]\]/g;
+
+export const PDF_REGEX = /!\[(.*?)\]\((.*?)(\.pdf)\)/g;
+export const TRANSCLUDED_PDF_REGEX =
+	/!\[\[(.*?)(\.pdf)\|(.*?)\]\]|!\[\[(.*?)(\.pdf)\]\]/g;


### PR DESCRIPTION
Fixes #544 , #233 , and maybe a little support to #120 .
This PR introduces the ability to embed PDF files directly into published notes using `<iframe>` tags.

**Changes:**

*   **PDF Embedding:**
    *   Supports `![[my_document.pdf]]` (transcluded) and `![](path/to/my_document.pdf)` (standard Markdown) syntaxes for local PDF files.
    *   Local PDFs are converted to base64 and embedded via an `<iframe>` with a `src` pointing to a CMS path (e.g., `/img/user/path/to/my_document.pdf`).
    *   External PDF links (e.g., `![](https://example.com/mydoc.pdf)`) are also embedded directly using an `<iframe>`.
*   **File Size Limit:**
    *   A 20MB file size limit is enforced for local PDFs. ( as discussed this in discord, over an old thread, and we can further add an option to manually set the limit, but ideally let's not make it so that git repo has to turn LFS).
    *   If a PDF exceeds this limit, a notice is shown to the user, and a standard Markdown link (or wikilink for transclusions) is generated instead of an embed.


**Purpose:**

*   To allow users to display PDF content inline within their digital garden notes, enhancing the richness of the content. (OOOH BOI , it's been so long since I wanted  this, ever since I started using DG  *_2 years now_ , never thought I would code it up and send a PR haha)


**Testing:**
- https://testing-pdf-67ho.vercel.app/ deployed from https://github.com/MostlyKIGuess/testing-pdf