### PR TITLE
fix: excalidraw zoom fix

### DIFF
--- a/src/compiler/ExcalidrawCompiler.ts
+++ b/src/compiler/ExcalidrawCompiler.ts
@@ -56,7 +56,9 @@ export class ExcalidrawCompiler {
 			}
 
 			// Set zoom level to 1
-			excaliDrawJson.appState?.zoom = { value: 1 };
+			if (excaliDrawJson.appState) {
+				excaliDrawJson.appState.zoom = { value: 1 };
+			}
 
 			excaliDrawCode += excalidraw(
 				JSON.stringify(excaliDrawJson),


### PR DESCRIPTION
This will override the zoom state to 1 to fit the drawing properly on load.