### PR TITLE
Fix invalid YAML escape sequence in wikilinks with aliases

### DIFF
--- a/src/compiler/FrontmatterCompiler.test.ts
+++ b/src/compiler/FrontmatterCompiler.test.ts
@@ -1,0 +1,203 @@
+import { FrontMatterCache } from "obsidian";
+import { FrontmatterCompiler } from "./FrontmatterCompiler";
+import DigitalGardenSettings from "../models/settings";
+import { PublishFile } from "../publishFile/PublishFile";
+
+jest.mock("obsidian");
+
+// Obsidian adds custom methods to String prototype
+// We need to polyfill these for tests
+declare global {
+	interface String {
+		contains(searchString: string): boolean;
+	}
+}
+
+if (!String.prototype.contains) {
+	String.prototype.contains = function (searchString: string): boolean {
+		return this.includes(searchString);
+	};
+}
+
+describe("FrontmatterCompiler", () => {
+	const createMockSettings = (
+		overrides: Partial<DigitalGardenSettings> = {},
+	): DigitalGardenSettings => {
+		return {
+			pathRewriteRules: "",
+			slugifyEnabled: false,
+			noteIconKey: "note-icon",
+			defaultNoteIcon: "",
+			showNoteIconOnTitle: false,
+			showNoteIconInFileTree: false,
+			showNoteIconOnInternalLink: false,
+			showNoteIconOnBackLink: false,
+			showCreatedTimestamp: false,
+			showUpdatedTimestamp: false,
+			contentClassesKey: "",
+			defaultNoteSettings: {
+				dgHomeLink: false,
+				dgPassFrontmatter: false,
+				dgShowBacklinks: false,
+				dgShowLocalGraph: false,
+				dgShowInlineTitle: false,
+				dgShowFileTree: false,
+				dgEnableSearch: false,
+				dgShowToc: false,
+				dgLinkPreview: false,
+				dgShowTags: false,
+			},
+			...overrides,
+		} as DigitalGardenSettings;
+	};
+
+	const createMockPublishFile = (path: string): PublishFile => {
+		return {
+			getPath: () => path,
+			meta: {
+				getCreatedAt: () => undefined,
+				getUpdatedAt: () => undefined,
+			},
+		} as unknown as PublishFile;
+	};
+
+	/**
+	 * Checks if the YAML content contains invalid escape sequences.
+	 * In YAML/JSON double-quoted strings, \| is not a valid escape sequence.
+	 * This causes YAML parsers (like js-yaml used by Eleventy) to fail.
+	 */
+	const hasInvalidYamlEscapeSequence = (yamlContent: string): boolean => {
+		// Check for \| which is an invalid escape sequence in YAML/JSON
+		// The backslash-pipe pattern appears as \\| in the raw string
+		return yamlContent.includes("\\|");
+	};
+
+	describe("compile", () => {
+		it("should produce valid YAML when frontmatter contains wikilinks with pipe aliases", () => {
+			// This test verifies the bug fix for wikilinks with pipes in frontmatter.
+			// When dgPassFrontmatter is enabled and frontmatter contains wikilinks
+			// like [[path|alias]], the compiled output must be valid YAML.
+			//
+			// The bug: wikilinks get expanded to [[full/path\|alias]] where \| is
+			// used to escape the pipe. When this is JSON.stringify'd and wrapped
+			// in YAML delimiters, \| becomes an invalid YAML escape sequence.
+
+			const settings = createMockSettings({
+				defaultNoteSettings: {
+					dgHomeLink: false,
+					dgPassFrontmatter: true,
+					dgShowBacklinks: false,
+					dgShowLocalGraph: false,
+					dgShowInlineTitle: false,
+					dgShowFileTree: false,
+					dgEnableSearch: false,
+					dgShowToc: false,
+					dgLinkPreview: false,
+					dgShowTags: false,
+				},
+			});
+
+			const compiler = new FrontmatterCompiler(settings);
+			const mockFile = createMockPublishFile("test/note.md");
+
+			// Simulate frontmatter with wikilinks containing pipe aliases
+			// This is what the content looks like AFTER convertLinksToFullPath runs
+			// With the fix, pipes are NOT escaped (using | not \|)
+			const frontmatterWithWikilinks: FrontMatterCache = {
+				"dg-publish": true,
+				county: "[[ACKS/Blightlands/Region/Ashborne County|Ashborne County]]",
+				duchy: "[[Duchy of Killifern]]",
+				position: { start: { line: 0 }, end: { line: 5 } },
+			} as unknown as FrontMatterCache;
+
+			const result = compiler.compile(mockFile, frontmatterWithWikilinks);
+
+			// The output should be wrapped in YAML delimiters
+			expect(result).toMatch(/^---\n/);
+			expect(result).toMatch(/\n---\n$/);
+
+			// Extract the content between the YAML delimiters
+			const yamlContent = result.slice(4, -5);
+
+			// CRITICAL: The output must not contain \| as an escape sequence
+			expect(hasInvalidYamlEscapeSequence(yamlContent)).toBe(false);
+		});
+
+		it("should handle frontmatter with simple wikilinks (no pipe alias)", () => {
+			const settings = createMockSettings({
+				defaultNoteSettings: {
+					dgHomeLink: false,
+					dgPassFrontmatter: true,
+					dgShowBacklinks: false,
+					dgShowLocalGraph: false,
+					dgShowInlineTitle: false,
+					dgShowFileTree: false,
+					dgEnableSearch: false,
+					dgShowToc: false,
+					dgLinkPreview: false,
+					dgShowTags: false,
+				},
+			});
+
+			const compiler = new FrontmatterCompiler(settings);
+			const mockFile = createMockPublishFile("test/note.md");
+
+			const frontmatter: FrontMatterCache = {
+				"dg-publish": true,
+				related: "[[Some Other Note]]",
+				position: { start: { line: 0 }, end: { line: 3 } },
+			} as unknown as FrontMatterCache;
+
+			const result = compiler.compile(mockFile, frontmatter);
+
+			expect(result).toMatch(/^---\n/);
+			expect(result).toMatch(/\n---\n$/);
+
+			// Simple wikilinks should pass through without issues
+			expect(result).toContain("Some Other Note");
+
+			// Should not have any invalid escape sequences
+			const yamlContent = result.slice(4, -5);
+			expect(hasInvalidYamlEscapeSequence(yamlContent)).toBe(false);
+		});
+
+		it("should preserve wikilink content while producing valid YAML", () => {
+			// Verifies that the wikilink display name is preserved in the output
+			// while ensuring the output is valid YAML
+
+			const settings = createMockSettings({
+				defaultNoteSettings: {
+					dgHomeLink: false,
+					dgPassFrontmatter: true,
+					dgShowBacklinks: false,
+					dgShowLocalGraph: false,
+					dgShowInlineTitle: false,
+					dgShowFileTree: false,
+					dgEnableSearch: false,
+					dgShowToc: false,
+					dgLinkPreview: false,
+					dgShowTags: false,
+				},
+			});
+
+			const compiler = new FrontmatterCompiler(settings);
+			const mockFile = createMockPublishFile("test/note.md");
+
+			const frontmatter: FrontMatterCache = {
+				"dg-publish": true,
+				link: "[[Some/Path/To/Note|Display Name]]",
+				position: { start: { line: 0 }, end: { line: 3 } },
+			} as unknown as FrontMatterCache;
+
+			const result = compiler.compile(mockFile, frontmatter);
+
+			// The display name should be preserved
+			expect(result).toContain("Display Name");
+			expect(result).toContain("Some/Path/To/Note");
+
+			// But it must be valid YAML (no invalid escape sequences)
+			const yamlContent = result.slice(4, -5);
+			expect(hasInvalidYamlEscapeSequence(yamlContent)).toBe(false);
+		});
+	});
+});

--- a/src/compiler/GardenPageCompiler.test.ts
+++ b/src/compiler/GardenPageCompiler.test.ts
@@ -1,0 +1,278 @@
+import { MetadataCache, TFile, Vault } from "obsidian";
+import DigitalGardenSettings from "../models/settings";
+import { GardenPageCompiler } from "./GardenPageCompiler";
+import { PublishFile } from "../publishFile/PublishFile";
+
+// Mock obsidian module with getLinkpath
+jest.mock("obsidian", () => ({
+	getLinkpath: jest.fn((link: string) => {
+		// Extract filename from wikilink, handling headers
+		const hashIndex = link.indexOf("#");
+
+		if (hashIndex !== -1) {
+			return link.substring(0, hashIndex);
+		}
+
+		return link;
+	}),
+}));
+
+// Obsidian adds custom methods to String prototype
+declare global {
+	interface String {
+		contains(searchString: string): boolean;
+	}
+}
+
+if (!String.prototype.contains) {
+	String.prototype.contains = function (searchString: string): boolean {
+		return this.includes(searchString);
+	};
+}
+
+describe("GardenPageCompiler", () => {
+	describe("convertLinksToFullPath", () => {
+		const createMockSettings = (
+			overrides: Partial<DigitalGardenSettings> = {},
+		): DigitalGardenSettings => {
+			return {
+				pathRewriteRules: "",
+				slugifyEnabled: false,
+				...overrides,
+			} as DigitalGardenSettings;
+		};
+
+		const createCompiler = (
+			metadataCacheMock: Partial<MetadataCache> = {},
+		) => {
+			return new GardenPageCompiler(
+				{} as Vault,
+				createMockSettings(),
+				{
+					getFirstLinkpathDest: jest.fn(),
+					...metadataCacheMock,
+				} as unknown as MetadataCache,
+				jest.fn(),
+			);
+		};
+
+		const createMockPublishFile = (path: string): PublishFile => {
+			return {
+				getPath: () => path,
+				meta: {
+					getCreatedAt: () => undefined,
+					getUpdatedAt: () => undefined,
+				},
+			} as unknown as PublishFile;
+		};
+
+		it("should output wikilinks with unescaped pipe for site template compatibility", async () => {
+			// The site template (eleventy) splits wikilinks on "|" to extract
+			// the display name. Using escaped "\|" breaks this functionality.
+			//
+			// Site template code:
+			//   const [fileLink, linkTitle] = p1.split("|");
+			//
+			// This test ensures wikilinks use plain "|" not "\|"
+
+			const mockLinkedFile = {
+				path: "folder/Target Note.md",
+				extension: "md",
+			} as TFile;
+
+			const compiler = createCompiler({
+				getFirstLinkpathDest: jest.fn().mockReturnValue(mockLinkedFile),
+			});
+
+			const mockFile = createMockPublishFile("source/note.md");
+
+			const inputText =
+				"Check out [[Target Note|My Alias]] for more info.";
+
+			const convertStep = compiler.convertLinksToFullPath(mockFile);
+			const result = await convertStep(inputText);
+
+			// The output should use plain pipe, not escaped pipe
+			expect(result).toContain("[[folder/Target Note|My Alias]]");
+			expect(result).not.toContain("\\|");
+		});
+
+		it("should preserve wikilink structure when file is not found", async () => {
+			// When a linked file doesn't exist, the compiler should still
+			// output a valid wikilink format that the site template can parse
+
+			const compiler = createCompiler({
+				getFirstLinkpathDest: jest.fn().mockReturnValue(null),
+			});
+
+			const mockFile = createMockPublishFile("source/note.md");
+			const inputText = "See [[Missing Note|Display Text]] for details.";
+
+			const convertStep = compiler.convertLinksToFullPath(mockFile);
+			const result = await convertStep(inputText);
+
+			// Even for missing files, use plain pipe
+			expect(result).toContain("|Display Text]]");
+			expect(result).not.toContain("\\|");
+		});
+
+		it("should handle wikilinks with headers and aliases", async () => {
+			const mockLinkedFile = {
+				path: "docs/Guide.md",
+				extension: "md",
+			} as TFile;
+
+			const compiler = createCompiler({
+				getFirstLinkpathDest: jest.fn().mockReturnValue(mockLinkedFile),
+			});
+
+			const mockFile = createMockPublishFile("notes/index.md");
+			const inputText = "Read [[Guide#Section|the section]] carefully.";
+
+			const convertStep = compiler.convertLinksToFullPath(mockFile);
+			const result = await convertStep(inputText);
+
+			// Should preserve header and use plain pipe
+			expect(result).toContain("[[docs/Guide#Section|the section]]");
+			expect(result).not.toContain("\\|");
+		});
+
+		it("should handle canvas files correctly", async () => {
+			const mockCanvasFile = {
+				path: "diagrams/flowchart.canvas",
+				extension: "canvas",
+			} as TFile;
+
+			const compiler = createCompiler({
+				getFirstLinkpathDest: jest.fn().mockReturnValue(mockCanvasFile),
+			});
+
+			const mockFile = createMockPublishFile("notes/overview.md");
+			const inputText = "View the [[flowchart|Flowchart Diagram]] here.";
+
+			const convertStep = compiler.convertLinksToFullPath(mockFile);
+			const result = await convertStep(inputText);
+
+			// Canvas files should keep .canvas extension and use plain pipe
+			expect(result).toContain(
+				"[[diagrams/flowchart.canvas|Flowchart Diagram]]",
+			);
+			expect(result).not.toContain("\\|");
+		});
+
+		it("should handle wikilinks without aliases", async () => {
+			const mockLinkedFile = {
+				path: "articles/Simple Note.md",
+				extension: "md",
+			} as TFile;
+
+			const compiler = createCompiler({
+				getFirstLinkpathDest: jest.fn().mockReturnValue(mockLinkedFile),
+			});
+
+			const mockFile = createMockPublishFile("index.md");
+			const inputText = "Check [[Simple Note]] for info.";
+
+			const convertStep = compiler.convertLinksToFullPath(mockFile);
+			const result = await convertStep(inputText);
+
+			// Without explicit alias, the filename becomes the display name
+			expect(result).toContain("[[articles/Simple Note|Simple Note]]");
+			expect(result).not.toContain("\\|");
+		});
+
+		it("should produce output compatible with site template link filter", async () => {
+			// This test simulates exactly what the site template does:
+			// It uses a regex to find [[...|...]] and splits on "|"
+
+			const mockLinkedFile = {
+				path: "ACKS/Blightlands/Region/Ashborne County.md",
+				extension: "md",
+			} as TFile;
+
+			const compiler = createCompiler({
+				getFirstLinkpathDest: jest.fn().mockReturnValue(mockLinkedFile),
+			});
+
+			const mockFile = createMockPublishFile("notes/town.md");
+			const inputText = "Located in [[Ashborne County|Ashborne County]].";
+
+			const convertStep = compiler.convertLinksToFullPath(mockFile);
+			const result = await convertStep(inputText);
+
+			// Simulate site template parsing
+			const linkRegex = /\[\[(.*?\|.*?)\]\]/g;
+			const match = linkRegex.exec(result);
+
+			expect(match).not.toBeNull();
+
+			if (match) {
+				const [fileLink, linkTitle] = match[1].split("|");
+
+				expect(fileLink).toBe(
+					"ACKS/Blightlands/Region/Ashborne County",
+				);
+				expect(linkTitle).toBe("Ashborne County");
+			}
+		});
+	});
+
+	describe("generateTransclusionHeader", () => {
+		const getTestCompiler = (settings: Partial<DigitalGardenSettings>) => {
+			return new GardenPageCompiler(
+				{} as Vault,
+				{
+					pathRewriteRules: "",
+					...settings,
+				} as DigitalGardenSettings,
+				{} as MetadataCache,
+				jest.fn(),
+			);
+		};
+
+		it("should replace {{title}} with the basename of the file", () => {
+			const testCompiler = getTestCompiler({});
+			const EXPECTED_TITLE = "expected";
+
+			const result = testCompiler.generateTransclusionHeader(
+				"# {{title}}",
+				{ basename: EXPECTED_TITLE } as TFile,
+			);
+
+			expect(result).toBe(`# ${EXPECTED_TITLE}`);
+		});
+
+		it("should add # to header if it is not a markdown header", () => {
+			const testCompiler = getTestCompiler({});
+
+			const result = testCompiler.generateTransclusionHeader(
+				"header",
+				{} as TFile,
+			);
+
+			expect(result).toBe(`# header`);
+		});
+
+		it("Ensures that header has space after #", () => {
+			const testCompiler = getTestCompiler({});
+
+			const result = testCompiler.generateTransclusionHeader(
+				"###header",
+				{} as TFile,
+			);
+
+			expect(result).toBe(`### header`);
+		});
+
+		it("Returns undefined if heading is undefined", () => {
+			const testCompiler = getTestCompiler({});
+
+			const result = testCompiler.generateTransclusionHeader(
+				undefined,
+				{} as TFile,
+			);
+
+			expect(result).toBe(undefined);
+		});
+	});
+});

--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -298,7 +298,7 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 					if (!linkedFile) {
 						convertedText = convertedText.replace(
 							linkMatch,
-							`[[${linkedFileName}${headerPath}\\|${linkDisplayName}]]`,
+							`[[${linkedFileName}${headerPath}|${linkDisplayName}]]`,
 						);
 						continue;
 					}
@@ -320,7 +320,7 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 
 						convertedText = convertedText.replace(
 							linkMatch,
-							`[[${linkPath}${headerPath}\\|${linkDisplayName}]]`,
+							`[[${linkPath}${headerPath}|${linkDisplayName}]]`,
 						);
 					}
 				} catch (e) {

--- a/src/dg-testVault/016 Frontmatter wikilinks.md
+++ b/src/dg-testVault/016 Frontmatter wikilinks.md
@@ -1,0 +1,11 @@
+---
+dg-publish: true
+county: "[[000 Home]]"
+related: "[[001 Links]]"
+---
+This note tests wikilinks in frontmatter values.
+
+The county field above has a wikilink that should be expanded to include
+the full path and an alias, but WITHOUT escaped pipes.
+
+Also testing body links: [[000 Home| Home with alias]]

--- a/src/test/integration/frontmatterWikilinks.test.ts
+++ b/src/test/integration/frontmatterWikilinks.test.ts
@@ -1,0 +1,217 @@
+import * as fs from "fs";
+import * as path from "path";
+import { FrontMatterCache, MetadataCache, TFile, Vault } from "obsidian";
+import { GardenPageCompiler } from "../../compiler/GardenPageCompiler";
+import { FrontmatterCompiler } from "../../compiler/FrontmatterCompiler";
+import DigitalGardenSettings from "../../models/settings";
+import { PublishFile } from "../../publishFile/PublishFile";
+
+// Mock obsidian module
+jest.mock("obsidian", () => ({
+	getLinkpath: jest.fn((link: string) => {
+		const hashIndex = link.indexOf("#");
+
+		if (hashIndex !== -1) {
+			return link.substring(0, hashIndex);
+		}
+
+		return link;
+	}),
+}));
+
+// Polyfill Obsidian's String.contains
+declare global {
+	interface String {
+		contains(searchString: string): boolean;
+	}
+}
+
+if (!String.prototype.contains) {
+	String.prototype.contains = function (searchString: string): boolean {
+		return this.includes(searchString);
+	};
+}
+
+describe("Integration: Frontmatter wikilinks", () => {
+	const TEST_VAULT_PATH = path.join(__dirname, "../../dg-testVault");
+
+	// Simulated file database for the test vault
+	const testVaultFiles: Record<string, { path: string; extension: string }> =
+		{
+			"000 Home": { path: "000 Home.md", extension: "md" },
+			"001 Links": { path: "001 Links.md", extension: "md" },
+			"002 Hidden page": { path: "002 Hidden page.md", extension: "md" },
+		};
+
+	const createMockSettings = (): DigitalGardenSettings => {
+		return {
+			pathRewriteRules: "",
+			slugifyEnabled: false,
+			noteIconKey: "note-icon",
+			defaultNoteIcon: "",
+			showNoteIconOnTitle: false,
+			showNoteIconInFileTree: false,
+			showNoteIconOnInternalLink: false,
+			showNoteIconOnBackLink: false,
+			showCreatedTimestamp: false,
+			showUpdatedTimestamp: false,
+			contentClassesKey: "",
+			customFilters: [],
+			defaultNoteSettings: {
+				dgHomeLink: false,
+				dgPassFrontmatter: true,
+				dgShowBacklinks: false,
+				dgShowLocalGraph: false,
+				dgShowInlineTitle: false,
+				dgShowFileTree: false,
+				dgEnableSearch: false,
+				dgShowToc: false,
+				dgLinkPreview: false,
+				dgShowTags: false,
+			},
+		} as unknown as DigitalGardenSettings;
+	};
+
+	const createMockMetadataCache = (): MetadataCache => {
+		return {
+			getFirstLinkpathDest: jest.fn((linkPath: string) => {
+				const file = testVaultFiles[linkPath];
+
+				if (file) {
+					return {
+						path: file.path,
+						extension: file.extension,
+					} as TFile;
+				}
+
+				return null;
+			}),
+			getCache: jest.fn(() => ({
+				frontmatter: {
+					"dg-publish": true,
+					county: "[[000 Home]]",
+					related: "[[001 Links]]",
+				},
+			})),
+		} as unknown as MetadataCache;
+	};
+
+	it("should produce wikilinks with unescaped pipes in compiled output", async () => {
+		const testFilePath = path.join(
+			TEST_VAULT_PATH,
+			"016 Frontmatter wikilinks.md",
+		);
+		const fileContent = fs.readFileSync(testFilePath, "utf-8");
+
+		const settings = createMockSettings();
+		const metadataCache = createMockMetadataCache();
+
+		const compiler = new GardenPageCompiler(
+			{} as Vault,
+			settings,
+			metadataCache,
+			jest.fn(),
+		);
+
+		// Test the convertLinksToFullPath step directly
+		const mockFile = {
+			getPath: () => "016 Frontmatter wikilinks.md",
+			meta: {
+				getCreatedAt: () => undefined,
+				getUpdatedAt: () => undefined,
+			},
+		} as unknown as PublishFile;
+
+		const convertStep = compiler.convertLinksToFullPath(mockFile);
+		const result = await convertStep(fileContent);
+
+		// Verify: Body wikilinks should have plain pipes, not escaped
+		expect(result).toContain("[[000 Home|");
+		expect(result).not.toContain("\\|");
+
+		// The aliased link in body should be converted properly
+		expect(result).toContain("Home with alias]]");
+	});
+
+	it("should produce valid YAML when frontmatter contains expanded wikilinks", () => {
+		const settings = createMockSettings();
+		const frontmatterCompiler = new FrontmatterCompiler(settings);
+
+		// Simulate frontmatter after wikilinks have been expanded (with plain pipes)
+		const expandedFrontmatter = {
+			"dg-publish": true,
+			county: "[[000 Home|000 Home]]",
+			related: "[[001 Links|001 Links]]",
+			position: { start: { line: 0 }, end: { line: 5 } },
+		};
+
+		const mockFile = {
+			getPath: () => "016 Frontmatter wikilinks.md",
+			meta: {
+				getCreatedAt: () => undefined,
+				getUpdatedAt: () => undefined,
+			},
+		} as unknown as PublishFile;
+
+		const result = frontmatterCompiler.compile(
+			mockFile,
+			expandedFrontmatter as unknown as FrontMatterCache,
+		);
+
+		// Should be wrapped in YAML delimiters
+		expect(result).toMatch(/^---\n/);
+		expect(result).toMatch(/\n---\n$/);
+
+		// Should NOT contain escaped pipes
+		expect(result).not.toContain("\\|");
+
+		// Should contain the wikilink content
+		expect(result).toContain("000 Home");
+		expect(result).toContain("001 Links");
+
+		// The JSON should be parseable
+		const yamlContent = result.slice(4, -5);
+		expect(() => JSON.parse(yamlContent)).not.toThrow();
+	});
+
+	it("reproduces the original bug scenario with county wikilink", async () => {
+		// This test simulates Ryan's exact scenario:
+		// - A note with county: "[[Ashborne County]]" in frontmatter
+		// - The same wikilink [[Ashborne County]] appears in body
+		// - After compilation, both should use plain | not \|
+
+		const fileContent = `---
+dg-publish: true
+county: "[[000 Home]]"
+---
+**Belongs To:** [[000 Home]]
+`;
+
+		const settings = createMockSettings();
+		const metadataCache = createMockMetadataCache();
+
+		const compiler = new GardenPageCompiler(
+			{} as Vault,
+			settings,
+			metadataCache,
+			jest.fn(),
+		);
+
+		const mockFile = {
+			getPath: () => "test-note.md",
+			meta: {
+				getCreatedAt: () => undefined,
+				getUpdatedAt: () => undefined,
+			},
+		} as unknown as PublishFile;
+
+		const convertStep = compiler.convertLinksToFullPath(mockFile);
+		const result = await convertStep(fileContent);
+
+		// The converted text should NOT have escaped pipes anywhere
+		expect(result).not.toContain("\\|");
+
+		// But should have the wikilink with alias (plain pipe)
+		expect(result).toContain("|000 Home]]");
+	});
+});


### PR DESCRIPTION
In front matter, wikilinks with aliases were being output as [[path\|alias]] with an escaped pipe character. This caused YAML parsing errors in Eleventy because \| is not a valid escape sequence in JSON/YAML strings.

**Background**
Right now, digital-garden doesn't have any SEO friendly meta tags or open graph tags. I've customized my template to include that, which requires custom front matter on my notes. This also, then, requires me to pass front matter through. Builds were failing due to the plugin not being able to parse links in the front matter.

A future change could be to include SEO based fields and a robots.txt as a part of the plugin configuration, but that is a lot bigger of a change than this.

**Fix**
Changed to use plain pipe [[path|alias]] which:
- Produces valid YAML frontmatter
- Works with the site template's split("|") link parsing
- Matches how the plugin already parses incoming wikilinks

Added comprehensive tests:
- FrontmatterCompiler tests for YAML validity
- GardenPageCompiler tests for wikilink conversion
- Integration tests using the test vault