### PR TITLE
Images will only be uploaded once

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "digitalgarden",
 	"name": "Digital Garden",
-	"version": "2.68.0",
+	"version": "2.68.1",
 	"minAppVersion": "1.10.0",
 	"description": "Publish your notes to the web for others to enjoy. For free.",
 	"author": "Ole Eskild Steensen",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "digitalgarden",
 	"name": "Digital Garden",
-	"version": "2.68.0",
+	"version": "2.68.1",
 	"minAppVersion": "1.10.0",
 	"description": "Publish your notes to the web for others to enjoy. For free.",
 	"author": "Ole Eskild Steensen",

--- a/src/compiler/CanvasCompiler.ts
+++ b/src/compiler/CanvasCompiler.ts
@@ -4,6 +4,7 @@ import { PublishFile } from "../publishFile/PublishFile";
 import DigitalGardenSettings from "../models/settings";
 import {
 	arrayBufferToBase64,
+	generateBlobHashFromBase64,
 	generateUrlPath,
 	getGardenPathForNote,
 	getRewriteRules,
@@ -320,7 +321,12 @@ export class CanvasCompiler {
 					const imageData = await this.vault.readBinary(linkedFile);
 					const imageBase64 = arrayBufferToBase64(imageData);
 					const imgPath = `/img/user/${linkedFile.path}`;
-					assets.push({ path: imgPath, content: imageBase64 });
+
+					assets.push({
+						path: imgPath,
+						content: imageBase64,
+						localHash: generateBlobHashFromBase64(imageBase64),
+					});
 
 					const altText = node.file.split("/").pop() || node.file;
 
@@ -461,7 +467,12 @@ export class CanvasCompiler {
 					const imageData = await this.vault.readBinary(linkedFile);
 					const imageBase64 = arrayBufferToBase64(imageData);
 					const bgPath = `/img/user/${linkedFile.path}`;
-					assets.push({ path: bgPath, content: imageBase64 });
+
+					assets.push({
+						path: bgPath,
+						content: imageBase64,
+						localHash: generateBlobHashFromBase64(imageBase64),
+					});
 
 					const bgSize =
 						node.backgroundStyle === "repeat"

--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -11,6 +11,7 @@ import { PathRewriteRule } from "../repositoryConnection/DigitalGardenSiteManage
 import Publisher from "../publisher/Publisher";
 import {
 	fixSvgForXmlSerializer,
+	generateBlobHashFromBase64,
 	generateUrlPath,
 	getGardenPathForNote,
 	getRewriteRules,
@@ -43,8 +44,7 @@ import { replaceBlockIDs } from "./replaceBlockIDs";
 export interface Asset {
 	path: string;
 	content: string;
-	// not set yet
-	remoteHash?: string;
+	localHash?: string;
 }
 export interface Assets {
 	images: Array<Asset>;
@@ -843,7 +843,11 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 							cmsImgPath,
 						)})`;
 
-						assets.push({ path: cmsImgPath, content: imageBase64 });
+						assets.push({
+							path: cmsImgPath,
+							content: imageBase64,
+							localHash: generateBlobHashFromBase64(imageBase64),
+						});
 
 						imageText = imageText.replace(
 							imageMatch,
@@ -933,7 +937,12 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 						const imageMarkdown = `![${imageName}](${encodeURI(
 							cmsImgPath,
 						)})`;
-						assets.push({ path: cmsImgPath, content: imageBase64 });
+
+						assets.push({
+							path: cmsImgPath,
+							content: imageBase64,
+							localHash: generateBlobHashFromBase64(imageBase64),
+						});
 
 						imageText = imageText.replace(
 							imageMatch,
@@ -1035,7 +1044,11 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 						const pdfBase64 = arrayBufferToBase64(pdfBinary);
 						const cmsPdfPath = `/img/user/${linkedFile.path}`;
 
-						assets.push({ path: cmsPdfPath, content: pdfBase64 });
+						assets.push({
+							path: cmsPdfPath,
+							content: pdfBase64,
+							localHash: generateBlobHashFromBase64(pdfBase64),
+						});
 
 						imageText = imageText.replace(
 							pdfMatch,
@@ -1140,7 +1153,11 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 						const pdfBase64 = arrayBufferToBase64(pdfBinary);
 						const cmsPdfPath = `/img/user/${linkedFile.path}`;
 
-						assets.push({ path: cmsPdfPath, content: pdfBase64 });
+						assets.push({
+							path: cmsPdfPath,
+							content: pdfBase64,
+							localHash: generateBlobHashFromBase64(pdfBase64),
+						});
 
 						imageText = imageText.replace(
 							pdfMatch,

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import {
+	generateBlobHashFromBase64,
 	getGardenPathForNote,
 	getRewriteRules,
 	wrapAround,
@@ -114,6 +115,43 @@ describe("utils", () => {
 	describe("wrapAround", () => {
 		it("wraps around a positive number", () => {
 			assert.strictEqual(wrapAround(5, 2), 1);
+		});
+	});
+
+	describe("generateBlobHashFromBase64", () => {
+		it("returns a 40-character hex string (SHA1 format)", () => {
+			// "Hello World" in base64
+			const base64Content = "SGVsbG8gV29ybGQ=";
+			const hash = generateBlobHashFromBase64(base64Content);
+
+			expect(hash).toMatch(/^[a-f0-9]{40}$/);
+		});
+
+		it("produces consistent hashes for identical content", () => {
+			const base64Content = "SGVsbG8gV29ybGQ=";
+			const hash1 = generateBlobHashFromBase64(base64Content);
+			const hash2 = generateBlobHashFromBase64(base64Content);
+
+			expect(hash1).toBe(hash2);
+		});
+
+		it("produces different hashes for different content", () => {
+			const content1 = "SGVsbG8gV29ybGQ="; // "Hello World"
+			const content2 = "R29vZGJ5ZSBXb3JsZA=="; // "Goodbye World"
+			const hash1 = generateBlobHashFromBase64(content1);
+			const hash2 = generateBlobHashFromBase64(content2);
+
+			expect(hash1).not.toBe(hash2);
+		});
+
+		it("matches Git blob hash format for known content", () => {
+			// "Hello World" (11 bytes) should produce Git blob hash
+			// Git computes: SHA1("blob 11\0Hello World")
+			const base64Content = "SGVsbG8gV29ybGQ=";
+			const hash = generateBlobHashFromBase64(base64Content);
+
+			// This hash has been verified to match GitHub's blob hashes in practice
+			expect(hash).toBe("5e1c309dae7f45e0f39b1bf3ac3cd9db12e7d689");
 		});
 	});
 });

--- a/src/views/SettingsView/SettingView.ts
+++ b/src/views/SettingsView/SettingView.ts
@@ -186,6 +186,24 @@ export default class SettingView {
 				});
 			});
 		this.initializeCustomFilterSettings();
+
+		new Setting(this.settingsRootElement)
+			.setName("Enable debug logging")
+			.setDesc(
+				"Show detailed logs in the developer console. Useful for troubleshooting.",
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.settings.logLevel === Logger.DEBUG)
+					.onChange(async (value) => {
+						this.settings.logLevel = value
+							? Logger.DEBUG
+							: undefined;
+						Logger.setLevel(value ? Logger.DEBUG : Logger.WARN);
+						await this.saveSettings();
+					});
+			});
+
 		prModal.titleEl.createEl("h1", "Site template settings");
 	}
 


### PR DESCRIPTION
Previously, if you republished a note with images it would re upload every image, making it annoying to re publish notes with lots of images due to the time it takes. This PR fixes that by actually checking the remote hash with the local one to see if it already exists or has been changed. 