### PR TITLE
Fix image and PDF preview in canvas pages

### DIFF
--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -96,6 +96,7 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 	async processTextNodeContent(
 		file: PublishFile,
 		text: string,
+		assets?: Asset[],
 	): Promise<string> {
 		// Apply compile steps relevant to text node content
 		// Note: We skip frontmatter conversion since text nodes don't have frontmatter
@@ -106,12 +107,22 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 			this.convertDataViews,
 			this.convertLinksToFullPath,
 			this.removeObsidianComments,
+			this.createSvgEmbeds,
 		];
 
-		return await this.runCompilerSteps(
+		const compiledText = await this.runCompilerSteps(
 			file,
 			CANVAS_TEXT_COMPILE_STEPS,
 		)(text);
+
+		const [processedText, collectedAssets] =
+			await this.convertEmbeddedAssets(file)(compiledText);
+
+		if (assets) {
+			assets.push(...collectedAssets);
+		}
+
+		return processedText;
 	}
 
 	private resolveLinkedFile = (


### PR DESCRIPTION
Canvas text nodes now run convertEmbeddedAssets and createSvgEmbeds, so [[image.png]] and [[file.pdf]] links in text nodes get converted to proper asset paths. PDF file nodes are served from /img/user/ instead of being routed through resolveFileToGardenUrl. Markdown file node iframes extract just the .content portion instead of showing the full page. Image links also get hover previews in tooltips.

The template also have updates for this to work. 