### PR TITLE
fix: local exporter does not copy logo and favicon

### DIFF
--- a/src/localExport/LocalExporter.ts
+++ b/src/localExport/LocalExporter.ts
@@ -41,6 +41,18 @@ export class LocalExporter {
 		await this.writeEnvFile(targetPath);
 		await this.writeNavigationOrder(targetPath);
 
+		await this.copyFromVault(
+			this.settings.faviconPath,
+			`${targetPath}/src/site/`,
+			"favicon",
+		);
+
+		await this.copyFromVault(
+			this.settings.logoPath,
+			`${targetPath}/src/site/`,
+			"logo",
+		);
+
 		const marked = await this.publisher.getFilesMarkedForPublishing();
 
 		const notesDir = path.join(targetPath, NOTE_PATH_BASE);
@@ -183,6 +195,29 @@ export class LocalExporter {
 			} catch {
 				// File doesn't exist, that's fine
 			}
+		}
+	}
+
+	private async copyFromVault(
+		sourcePath: string,
+		targetFolder: string,
+		rename?: string,
+	) {
+		if (sourcePath === "") return;
+		const sourceFile = this.vault.getFileByPath(sourcePath);
+
+		if (sourceFile) {
+			const targetPath = `${targetFolder}/${
+				rename ?? sourceFile.basename
+			}.${sourceFile.extension}`;
+
+			await fs.writeFile(
+				targetPath,
+				new DataView(await this.vault.readBinary(sourceFile)),
+			);
+			new Notice(`Copied file from ${sourcePath} to ${targetPath}`);
+		} else {
+			Logger.warn(`File not found at '${sourcePath}'`);
 		}
 	}
 

--- a/src/localExport/LocalExporter.ts
+++ b/src/localExport/LocalExporter.ts
@@ -43,13 +43,13 @@ export class LocalExporter {
 
 		await this.copyFromVault(
 			this.settings.faviconPath,
-			`${targetPath}/src/site/`,
+			path.join(targetPath, "/src/site/"),
 			"favicon",
 		);
 
 		await this.copyFromVault(
 			this.settings.logoPath,
-			`${targetPath}/src/site/`,
+			path.join(targetPath, "/src/site/"),
 			"logo",
 		);
 
@@ -207,15 +207,16 @@ export class LocalExporter {
 		const sourceFile = this.vault.getFileByPath(sourcePath);
 
 		if (sourceFile) {
-			const targetPath = `${targetFolder}/${
-				rename ?? sourceFile.basename
-			}.${sourceFile.extension}`;
+			const targetPath = path.join(
+				targetFolder,
+				`${rename ?? sourceFile.basename}.${sourceFile.extension}`,
+			);
 
 			await fs.writeFile(
 				targetPath,
-				new DataView(await this.vault.readBinary(sourceFile)),
+				Buffer.from(await this.vault.readBinary(sourceFile)),
 			);
-			new Notice(`Copied file from ${sourcePath} to ${targetPath}`);
+			Logger.debug(`Copied file from ${sourcePath} to ${targetPath}`);
 		} else {
 			Logger.warn(`File not found at '${sourcePath}'`);
 		}


### PR DESCRIPTION
Great project - this is exactly what I need, just a little bit of tweaking!
I don't want to use vercel or netlify but my good old static homepage.

The "Export to Local Path" is not copying favicon or logo - this PR fixes that!