### PR TITLE
fix(local-export): create subfolder notes on Windows

### DIFF
--- a/src/localExport/LocalExporter.ts
+++ b/src/localExport/LocalExporter.ts
@@ -239,7 +239,13 @@ export class LocalExporter {
 			const existingFiles = await this.listFilesRecursive(dir);
 
 			for (const filePath of existingFiles) {
-				const relativePath = path.relative(dir, filePath);
+				// Normalize to forward slashes so the lookup matches
+				// writtenPaths keys, which come from Obsidian vault paths
+				// (always forward-slash separated, even on Windows).
+				const relativePath = path
+					.relative(dir, filePath)
+					.split(path.sep)
+					.join("/");
 				const fileName = path.basename(filePath);
 
 				if (preservedFiles.has(fileName)) {


### PR DESCRIPTION
Normalize the relative path to forward slashes before checking it
against writtenPaths in cleanStaleFiles. On Windows, path.relative
returns backslash-separated paths while writtenPaths is keyed off
Obsidian vault paths (always forward-slash separated), so nested notes
were wrongly treated as stale and deleted immediately after being
written, with their parent directories then removed as empty. Root
notes were unaffected because they contain no separators.

Fixes #772