### PR TITLE
feat: dg-hide hides everywhere + new dg-hide-in-filetree flag

### DIFF
--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -1,11 +1,3 @@
-// Polyfill Obsidian's String.prototype extensions used in production code
-if (!String.prototype.contains) {
-	// eslint-disable-next-line no-extend-native
-	String.prototype.contains = function (str: string): boolean {
-		return this.indexOf(str) !== -1;
-	};
-}
-
 const obsidian = {};
 
 module.exports = obsidian;

--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -1,3 +1,11 @@
+// Polyfill Obsidian's String.prototype extensions used in production code
+if (!String.prototype.contains) {
+	// eslint-disable-next-line no-extend-native
+	String.prototype.contains = function (str: string): boolean {
+		return this.indexOf(str) !== -1;
+	};
+}
+
 const obsidian = {};
 
 module.exports = obsidian;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
 	preset: "ts-jest/presets/js-with-ts",
 	testEnvironment: "node",
+	setupFiles: ["./jest.setup.ts"],
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,11 @@
+// Polyfill Obsidian's String.prototype extensions used in production code
+if (!String.prototype.contains) {
+	// eslint-disable-next-line no-extend-native
+	Object.defineProperty(String.prototype, "contains", {
+		value(str: string): boolean {
+			return (this as string).indexOf(str) !== -1;
+		},
+		writable: true,
+		configurable: true,
+	});
+}

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "digitalgarden",
 	"name": "Digital Garden",
-	"version": "2.76.4",
+	"version": "2.77.0",
 	"minAppVersion": "1.10.0",
 	"description": "Publish your notes to the web for others to enjoy. For free.",
 	"author": "Ole Eskild Steensen",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "digitalgarden",
 	"name": "Digital Garden",
-	"version": "2.76.4",
+	"version": "2.77.0",
 	"minAppVersion": "1.10.0",
 	"description": "Publish your notes to the web for others to enjoy. For free.",
 	"author": "Ole Eskild Steensen",

--- a/src/compiler/FrontmatterCompiler.test.ts
+++ b/src/compiler/FrontmatterCompiler.test.ts
@@ -1,0 +1,83 @@
+import { FrontMatterCache } from "obsidian";
+import DigitalGardenSettings from "../models/settings";
+import { FrontmatterCompiler } from "./FrontmatterCompiler";
+import { PublishFile } from "../publishFile/PublishFile";
+
+jest.mock("obsidian");
+
+const getCompiler = (settings: Partial<DigitalGardenSettings> = {}) =>
+	new FrontmatterCompiler({
+		pathRewriteRules: "",
+		slugifyEnabled: true,
+		showCreatedTimestamp: false,
+		showUpdatedTimestamp: false,
+		showNoteIconInFileTree: false,
+		showNoteIconOnInternalLink: false,
+		showNoteIconOnTitle: false,
+		showNoteIconOnBackLink: false,
+		defaultNoteSettings: {},
+		...settings,
+	} as unknown as DigitalGardenSettings);
+
+const fakeFile = (path = "test.md") =>
+	({
+		getPath: () => path,
+		meta: {
+			getUpdatedAt: () => undefined,
+			getCreatedAt: () => undefined,
+		},
+	}) as unknown as PublishFile;
+
+const parsePublished = (compiled: string) => {
+	const match = compiled.match(/^---\n([\s\S]*?)\n---/);
+
+	if (!match) throw new Error("no frontmatter block found");
+
+	return JSON.parse(match[1]) as Record<string, unknown>;
+};
+
+describe("FrontmatterCompiler hide flags", () => {
+	it("maps dg-hide-in-filetree to hideInFiletree", () => {
+		const compiler = getCompiler();
+
+		const result = compiler.compile(fakeFile(), {
+			"dg-hide-in-filetree": true,
+		} as unknown as FrontMatterCache);
+
+		expect(parsePublished(result).hideInFiletree).toBe(true);
+	});
+
+	it("does not leak dg-hide-in-filetree into user properties", () => {
+		const compiler = getCompiler();
+
+		const result = compiler.compile(fakeFile(), {
+			"dg-hide-in-filetree": true,
+		} as unknown as FrontMatterCache);
+
+		const props = parsePublished(result)["dg-note-properties"] as Record<
+			string,
+			unknown
+		>;
+		expect(props["dg-hide-in-filetree"]).toBeUndefined();
+	});
+
+	it("still maps dg-hide to hide", () => {
+		const compiler = getCompiler();
+
+		const result = compiler.compile(fakeFile(), {
+			"dg-hide": true,
+		} as unknown as FrontMatterCache);
+
+		expect(parsePublished(result).hide).toBe(true);
+	});
+
+	it("still maps dg-hide-in-graph to hideInGraph", () => {
+		const compiler = getCompiler();
+
+		const result = compiler.compile(fakeFile(), {
+			"dg-hide-in-graph": true,
+		} as unknown as FrontMatterCache);
+
+		expect(parsePublished(result).hideInGraph).toBe(true);
+	});
+});

--- a/src/compiler/FrontmatterCompiler.test.ts
+++ b/src/compiler/FrontmatterCompiler.test.ts
@@ -28,6 +28,7 @@ const fakeFile = (path = "test.md") =>
 		},
 	}) as unknown as PublishFile;
 
+// compile() emits JSON (not YAML) between ---…--- fences
 const parsePublished = (compiled: string) => {
 	const match = compiled.match(/^---\n([\s\S]*?)\n---/);
 

--- a/src/compiler/FrontmatterCompiler.ts
+++ b/src/compiler/FrontmatterCompiler.ts
@@ -29,6 +29,7 @@ export type TPublishedFrontMatter = Record<string, unknown> & {
 	permalink?: string;
 	hide?: boolean;
 	hideInFiletree?: boolean;
+	hideInGraph?: boolean;
 };
 
 export class FrontmatterCompiler {

--- a/src/compiler/FrontmatterCompiler.ts
+++ b/src/compiler/FrontmatterCompiler.ts
@@ -16,6 +16,7 @@ export type TFrontmatter = Record<string, unknown> & {
 	"dg-home"?: boolean;
 	"dg-hide-in-graph"?: boolean;
 	"dg-hide"?: boolean;
+	"dg-hide-in-filetree"?: boolean;
 	"dg-pinned"?: boolean;
 	"dg-metatags"?: string;
 	tags?: string;
@@ -27,6 +28,7 @@ export type TPublishedFrontMatter = Record<string, unknown> & {
 	pinned?: boolean;
 	permalink?: string;
 	hide?: boolean;
+	hideInFiletree?: boolean;
 };
 
 export class FrontmatterCompiler {
@@ -149,6 +151,11 @@ export class FrontmatterCompiler {
 
 			if (baseFrontMatter["dg-hide"]) {
 				publishedFrontMatter["hide"] = baseFrontMatter["dg-hide"];
+			}
+
+			if (baseFrontMatter["dg-hide-in-filetree"]) {
+				publishedFrontMatter["hideInFiletree"] =
+					baseFrontMatter["dg-hide-in-filetree"];
 			}
 
 			if (baseFrontMatter["dg-hide-in-graph"]) {
@@ -310,6 +317,7 @@ export class FrontmatterCompiler {
 			"dg-path",
 			"dg-permalink",
 			"dg-hide",
+			"dg-hide-in-filetree",
 			"dg-hide-in-graph",
 			"dg-pinned",
 			"dg-metatags",


### PR DESCRIPTION
## Summary

Redefines the `dg-hide` frontmatter flag (plugin side) and adds a new `dg-hide-in-filetree` flag.

- **`dg-hide: true`** — now means "hide everywhere": filetree, search, graph, backlinks, RSS feed, and sitemap. The page is still published and reachable by its direct URL (so you can share the link manually). Previously it only hid the note from the filetree.
- **`dg-hide-in-filetree: true`** — NEW: the old filetree-only behavior.
- **`dg-hide-in-graph: true`** — unchanged (graph only).

This PR is the **plugin** half: it maps `dg-hide-in-filetree` → published `hideInFiletree` (alongside the existing `dg-hide` → `hide` and `dg-hide-in-graph` → `hideInGraph`), adds it to the skip-keys so it doesn't leak into `dg-note-properties`, and types both keys. The template half (which consumes these keys to actually hide notes from search/graph/feed/etc.) is a companion PR in `oleeskild/digitalgarden`.

Implements #708 and #295; resolves the confusion in #240 / #726 (`dg-enable-search` is a global setting, not a per-note flag — `dg-hide` is now the per-note answer).

## ⚠️ Breaking change

Existing notes using `dg-hide` to declutter the **filetree** will now also drop out of search, graph, feed, and sitemap. Migration: switch those notes to `dg-hide-in-filetree`. User-facing docs at docs.forestry.md should be updated to describe the three flags.

## Changes
- `src/compiler/FrontmatterCompiler.ts` — `dg-hide-in-filetree` → `hideInFiletree` mapping, skip-key, types.
- `src/compiler/FrontmatterCompiler.test.ts` — Jest tests for the mapping + no-leak.
- `jest.setup.ts` / `jest.config.js` — `String.prototype.contains` polyfill so the compiler tests run under Node.

## Test Plan
- [x] `npx jest src/compiler/FrontmatterCompiler.test.ts` — 4/4 pass
- [ ] Companion template PR merged so the published keys are actually consumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)