### PR TITLE
[codex] support named Base view embeds

### DIFF
--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -63,10 +63,13 @@ export type TCompilerStep = (
 export function selectBaseView(
 	baseFileText: string,
 	viewName?: string,
+	baseFileName?: string,
 ): string {
 	if (!viewName) {
 		return baseFileText;
 	}
+
+	const baseFileLabel = baseFileName ?? "Base file";
 
 	try {
 		const parsedBase = parseYaml(baseFileText);
@@ -84,6 +87,10 @@ export function selectBaseView(
 		);
 
 		if (!selectedView) {
+			Logger.warn(
+				`Base view "${viewName}" not found in ${baseFileLabel}. Embedding all views.`,
+			);
+
 			return baseFileText;
 		}
 
@@ -91,7 +98,12 @@ export function selectBaseView(
 			...parsedBase,
 			views: [selectedView],
 		});
-	} catch {
+	} catch (error) {
+		Logger.warn(
+			`Failed to parse ${baseFileLabel} while selecting view "${viewName}". Embedding all views.`,
+			error,
+		);
+
 		return baseFileText;
 	}
 }
@@ -100,10 +112,13 @@ export function createBaseCodeBlock(
 	baseFileText: string,
 	transclusionFileName: string,
 ): string {
-	const selectedViewName = transclusionFileName.split("#")[1]?.trim();
-	const selectedBaseFileText = selectBaseView(baseFileText, selectedViewName);
+	const [baseFileName, selectedViewName] = transclusionFileName.split("#");
 
-	return "\n```base\n" + selectedBaseFileText + "\n```\n";
+	return (
+		"\n```base\n" +
+		selectBaseView(baseFileText, selectedViewName?.trim(), baseFileName) +
+		"\n```\n"
+	);
 }
 
 export class GardenPageCompiler implements ITextNodeProcessor {

--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -5,6 +5,8 @@ import {
 	Vault,
 	arrayBufferToBase64,
 	getLinkpath,
+	parseYaml,
+	stringifyYaml,
 } from "obsidian";
 import DigitalGardenSettings from "../models/settings";
 import { PathRewriteRule } from "../repositoryConnection/DigitalGardenSiteManager";
@@ -57,6 +59,52 @@ export type TCompilerStep = (
 ) =>
 	| ((partiallyCompiledContent: string) => Promise<string>)
 	| ((partiallyCompiledContent: string) => string);
+
+export function selectBaseView(
+	baseFileText: string,
+	viewName?: string,
+): string {
+	if (!viewName) {
+		return baseFileText;
+	}
+
+	try {
+		const parsedBase = parseYaml(baseFileText);
+
+		if (
+			!parsedBase ||
+			typeof parsedBase !== "object" ||
+			!Array.isArray(parsedBase.views)
+		) {
+			return baseFileText;
+		}
+
+		const selectedView = parsedBase.views.find(
+			(view: { name?: unknown }) => view?.name === viewName,
+		);
+
+		if (!selectedView) {
+			return baseFileText;
+		}
+
+		return stringifyYaml({
+			...parsedBase,
+			views: [selectedView],
+		});
+	} catch {
+		return baseFileText;
+	}
+}
+
+export function createBaseCodeBlock(
+	baseFileText: string,
+	transclusionFileName: string,
+): string {
+	const selectedViewName = transclusionFileName.split("#")[1]?.trim();
+	const selectedBaseFileText = selectBaseView(baseFileText, selectedViewName);
+
+	return "\n```base\n" + selectedBaseFileText + "\n```\n";
+}
 
 export class GardenPageCompiler implements ITextNodeProcessor {
 	private readonly vault: Vault;
@@ -482,8 +530,10 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 						// Embed .base file contents as a ```base code block
 						const baseFileText = await this.vault.read(linkedFile);
 
-						const baseCodeBlock =
-							"\n```base\n" + baseFileText + "\n```\n";
+						const baseCodeBlock = createBaseCodeBlock(
+							baseFileText,
+							transclusionFileName,
+						);
 
 						transcludedText = transcludedText.replace(
 							transclusionMatch,

--- a/src/test/Compiler.test.ts
+++ b/src/test/Compiler.test.ts
@@ -5,6 +5,7 @@ import {
 	TFile,
 	Vault,
 } from "obsidian";
+import Logger from "js-logger";
 import DigitalGardenSettings from "../models/settings";
 import {
 	createBaseCodeBlock,
@@ -134,8 +135,15 @@ describe("Compiler", () => {
 			],
 		};
 
+		let warnSpy: jest.SpyInstance;
+
 		beforeEach(() => {
 			jest.clearAllMocks();
+			warnSpy = jest.spyOn(Logger, "warn").mockImplementation(() => {});
+		});
+
+		afterEach(() => {
+			warnSpy.mockRestore();
 		});
 
 		it("keeps only the requested named view while preserving global configuration", () => {
@@ -152,15 +160,60 @@ describe("Compiler", () => {
 				views: [parsedBase.views[1]],
 			});
 			expect(result).toBe("selected view yaml");
+			expect(warnSpy).not.toHaveBeenCalled();
 		});
 
-		it("leaves the Base unchanged when the requested view does not exist", () => {
+		it("returns the Base unchanged without parsing when no view is selected", () => {
+			const result = selectBaseView(baseFileText, undefined);
+
+			expect(parseYaml).not.toHaveBeenCalled();
+			expect(result).toBe(baseFileText);
+		});
+
+		it("leaves the Base unchanged and warns when the requested view does not exist", () => {
 			jest.mocked(parseYaml).mockReturnValue(parsedBase);
 
 			const result = selectBaseView(baseFileText, "Missing View");
 
 			expect(stringifyYaml).not.toHaveBeenCalled();
 			expect(result).toBe(baseFileText);
+
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Base view "Missing View" not found'),
+			);
+		});
+
+		it("falls back to the full Base and warns when the YAML cannot be parsed", () => {
+			jest.mocked(parseYaml).mockImplementation(() => {
+				throw new Error("bad yaml");
+			});
+
+			const result = selectBaseView(baseFileText, "Hardware Modules");
+
+			expect(result).toBe(baseFileText);
+
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining("Failed to parse"),
+				expect.any(Error),
+			);
+		});
+	});
+
+	describe("createBaseCodeBlock", () => {
+		const baseFileText = "original base yaml";
+
+		const parsedBase = {
+			views: [
+				{
+					type: "cards",
+					name: "Hardware Modules",
+					filters: 'file.hasTag("hardware")',
+				},
+			],
+		};
+
+		beforeEach(() => {
+			jest.clearAllMocks();
 		});
 
 		it("uses the fragment in a Base embed to build a single-view code block", () => {
@@ -173,6 +226,16 @@ describe("Compiler", () => {
 			);
 
 			expect(result).toBe("\n```base\nselected view yaml\n```\n");
+		});
+
+		it("embeds the full Base without parsing when no view fragment is present", () => {
+			const result = createBaseCodeBlock(
+				baseFileText,
+				"Access-Control.base",
+			);
+
+			expect(parseYaml).not.toHaveBeenCalled();
+			expect(result).toBe("\n```base\noriginal base yaml\n```\n");
 		});
 	});
 

--- a/src/test/Compiler.test.ts
+++ b/src/test/Compiler.test.ts
@@ -1,10 +1,23 @@
-import { MetadataCache, TFile, Vault } from "obsidian";
+import {
+	MetadataCache,
+	parseYaml,
+	stringifyYaml,
+	TFile,
+	Vault,
+} from "obsidian";
 import DigitalGardenSettings from "../models/settings";
-import { GardenPageCompiler } from "../compiler/GardenPageCompiler";
+import {
+	createBaseCodeBlock,
+	GardenPageCompiler,
+	selectBaseView,
+} from "../compiler/GardenPageCompiler";
 import { PublishFile } from "../publishFile/PublishFile";
 import { TRANSCLUDED_SVG_REGEX } from "../utils/regexes";
 
-jest.mock("obsidian");
+jest.mock("obsidian", () => ({
+	parseYaml: jest.fn(),
+	stringifyYaml: jest.fn(),
+}));
 
 describe("Compiler", () => {
 	const getTestCompiler = (settings: Partial<DigitalGardenSettings>) => {
@@ -94,6 +107,72 @@ describe("Compiler", () => {
 			expect(result).toBe(
 				"Link with [[folder/test#My Header\\|custom display]] text",
 			);
+		});
+	});
+
+	describe("selectBaseView", () => {
+		const baseFileText = "original base yaml";
+
+		const parsedBase = {
+			filters: 'file.inFolder("lessons")',
+			properties: {
+				module: {
+					displayName: "Module",
+				},
+			},
+			views: [
+				{
+					type: "table",
+					name: "Lessons by Module",
+					filters: 'file.hasProperty("module")',
+				},
+				{
+					type: "cards",
+					name: "Hardware Modules",
+					filters: 'file.hasTag("hardware")',
+				},
+			],
+		};
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it("keeps only the requested named view while preserving global configuration", () => {
+			jest.mocked(parseYaml).mockReturnValue(parsedBase);
+			jest.mocked(stringifyYaml).mockReturnValue("selected view yaml");
+
+			const result = selectBaseView(baseFileText, "Hardware Modules");
+
+			expect(parseYaml).toHaveBeenCalledWith(baseFileText);
+
+			expect(stringifyYaml).toHaveBeenCalledWith({
+				filters: parsedBase.filters,
+				properties: parsedBase.properties,
+				views: [parsedBase.views[1]],
+			});
+			expect(result).toBe("selected view yaml");
+		});
+
+		it("leaves the Base unchanged when the requested view does not exist", () => {
+			jest.mocked(parseYaml).mockReturnValue(parsedBase);
+
+			const result = selectBaseView(baseFileText, "Missing View");
+
+			expect(stringifyYaml).not.toHaveBeenCalled();
+			expect(result).toBe(baseFileText);
+		});
+
+		it("uses the fragment in a Base embed to build a single-view code block", () => {
+			jest.mocked(parseYaml).mockReturnValue(parsedBase);
+			jest.mocked(stringifyYaml).mockReturnValue("selected view yaml");
+
+			const result = createBaseCodeBlock(
+				baseFileText,
+				"Access-Control.base#Hardware Modules",
+			);
+
+			expect(result).toBe("\n```base\nselected view yaml\n```\n");
 		});
 	});
 


### PR DESCRIPTION
## Summary

- honor the view selector in `![[File.base#ViewName]]` embeds
- preserve global Base configuration while narrowing the emitted `views` array to the selected view
- retain the existing all-views behavior when no selector is supplied, the requested view is missing, or YAML parsing fails
- add regression coverage for selected and unknown views

## Root cause

The publisher resolved the `.base` file correctly, but discarded the `#ViewName` fragment and emitted the entire Base YAML as a fenced `base` block. The site renderer therefore always started with the first view and could not distinguish multiple embeds of the same Base file.

## Impact

Published embeds such as `![[Access-Control.base#Hardware Modules]]` now render only the requested view, including that view's filters and display configuration.

Closes #792.

## Validation

- `npm test -- --runInBand` — 47 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run check-formatting`
- `npm run build`
