### PR TITLE
Add Content base directory setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ If your Eleventy garden template lives in a **subdirectory** of the repo instead
 | _(empty)_ (default)   | `src/site/notes/`       | `.env`        |
 | `Web`                 | `Web/src/site/notes/`   | `Web/.env`    |
 
-This affects **GitHub publishing**, **"Load remote settings"**, and **local export** consistently. Leaving the field empty keeps the historical repo-root behavior unchanged.
+This affects **GitHub publishing**, **"Load remote settings"**, **template updates**, and **local export** consistently. The setting only applies to self-hosted (GitHub) publishing — it is ignored on managed platforms like Forestry. Values containing `..` segments are invalid and treated as empty. Leaving the field empty keeps the historical repo-root behavior unchanged.
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,19 @@ You can export your garden to a local folder instead of publishing to GitHub. Th
 
 This exports all notes marked with `dg-publish: true` and their images to the local folder, ready for the Eleventy build. Note that publish status tracking and diffing are not available with local export — it's a full export each time.
 
+## Publishing into a subfolder / monorepo
+
+By default the plugin assumes the [digitalgarden](https://github.com/oleeskild/digitalgarden) template lives at the **root** of your target repository (notes go to `src/site/notes/`, images to `src/site/img/user/`, settings to `.env`).
+
+If your Eleventy garden template lives in a **subdirectory** of the repo instead — a monorepo layout where, for example, the garden is under `Web/` — set the **Content base directory (advanced)** field in the GitHub settings to that subfolder (e.g. `Web`). Every published path is then prefixed with it:
+
+| Setting               | Notes are written to    | Settings file |
+| --------------------- | ----------------------- | ------------- |
+| _(empty)_ (default)   | `src/site/notes/`       | `.env`        |
+| `Web`                 | `Web/src/site/notes/`   | `Web/.env`    |
+
+This affects **GitHub publishing**, **"Load remote settings"**, and **local export** consistently. Leaving the field empty keeps the historical repo-root behavior unchanged.
+
 ## Local development
 
 NOTE: this plugin contains a testing vault at `src/dg-testVault`, which is recommended for local development.

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
 	preset: "ts-jest/presets/js-with-ts",
 	testEnvironment: "node",
 	setupFiles: ["./jest.setup.ts"],
+	moduleNameMapper: {"^src/(.*)$": "<rootDir>/src/$1",},
 };

--- a/main.ts
+++ b/main.ts
@@ -121,6 +121,7 @@ const DEFAULT_SETTINGS: DigitalGardenSettings = {
 
 	logLevel: undefined,
 	localExportPath: "",
+	contentBaseDir: "",
 };
 
 Logger.useDefaults({

--- a/src/localExport/LocalExporter.ts
+++ b/src/localExport/LocalExporter.ts
@@ -7,7 +7,7 @@ import Publisher from "../publisher/Publisher";
 import {
 	NOTE_PATH_BASE,
 	IMAGE_PATH_BASE,
-	contentBaseDir,
+	normalizeContentBaseDir,
 } from "../publisher/paths";
 import { generateEnvValues, serializeEnvValues } from "../utils/envSettings";
 
@@ -39,7 +39,7 @@ export class LocalExporter {
 			throw new Error("localExportPath is not configured");
 		}
 
-		const base = contentBaseDir(this.settings);
+		const base = normalizeContentBaseDir(this.settings.contentBaseDir);
 
 		await this.validateTargetPath(targetPath);
 		await this.writeEnvFile(targetPath);
@@ -157,7 +157,7 @@ export class LocalExporter {
 	}
 
 	private async validateTargetPath(targetPath: string): Promise<void> {
-		const base = contentBaseDir(this.settings);
+		const base = normalizeContentBaseDir(this.settings.contentBaseDir);
 
 		try {
 			await fs.access(targetPath);
@@ -184,7 +184,7 @@ export class LocalExporter {
 	}
 
 	private async writeEnvFile(targetPath: string): Promise<void> {
-		const base = contentBaseDir(this.settings);
+		const base = normalizeContentBaseDir(this.settings.contentBaseDir);
 		const envValues = generateEnvValues(this.settings);
 		const envContent = serializeEnvValues(envValues);
 
@@ -196,7 +196,7 @@ export class LocalExporter {
 	}
 
 	private async writeNavigationOrder(targetPath: string): Promise<void> {
-		const base = contentBaseDir(this.settings);
+		const base = normalizeContentBaseDir(this.settings.contentBaseDir);
 
 		const navOrderPath = path.join(
 			targetPath,

--- a/src/localExport/LocalExporter.ts
+++ b/src/localExport/LocalExporter.ts
@@ -3,10 +3,12 @@ import fs from "fs/promises";
 import path from "path";
 import Logger from "js-logger";
 import DigitalGardenSettings from "../models/settings";
-import Publisher, {
+import Publisher from "../publisher/Publisher";
+import {
 	NOTE_PATH_BASE,
 	IMAGE_PATH_BASE,
-} from "../publisher/Publisher";
+	contentBaseDir,
+} from "../publisher/paths";
 import { generateEnvValues, serializeEnvValues } from "../utils/envSettings";
 
 const PRESERVED_FILES = new Set(["notes.json", "notes.11tydata.js"]);
@@ -37,6 +39,8 @@ export class LocalExporter {
 			throw new Error("localExportPath is not configured");
 		}
 
+		const base = contentBaseDir(this.settings);
+
 		await this.validateTargetPath(targetPath);
 		await this.writeEnvFile(targetPath);
 		await this.writeNavigationOrder(targetPath);
@@ -44,7 +48,7 @@ export class LocalExporter {
 		try {
 			await this.copyFromVault(
 				this.settings.faviconPath,
-				path.join(targetPath, "src", "site"),
+				path.join(targetPath, base, "src", "site"),
 				"favicon.svg",
 			);
 		} catch (e) {
@@ -54,7 +58,7 @@ export class LocalExporter {
 		try {
 			await this.copyFromVault(
 				this.settings.logoPath,
-				path.join(targetPath, "src", "site"),
+				path.join(targetPath, base, "src", "site"),
 				"logo",
 			);
 		} catch (e) {
@@ -63,8 +67,8 @@ export class LocalExporter {
 
 		const marked = await this.publisher.getFilesMarkedForPublishing();
 
-		const notesDir = path.join(targetPath, NOTE_PATH_BASE);
-		const imagesDir = path.join(targetPath, IMAGE_PATH_BASE);
+		const notesDir = path.join(targetPath, base, NOTE_PATH_BASE);
+		const imagesDir = path.join(targetPath, base, IMAGE_PATH_BASE);
 
 		await fs.mkdir(notesDir, { recursive: true });
 		await fs.mkdir(imagesDir, { recursive: true });
@@ -92,6 +96,7 @@ export class LocalExporter {
 				for (const image of assets.images) {
 					const imagePath = path.join(
 						targetPath,
+						base,
 						"src",
 						"site",
 						image.path,
@@ -152,6 +157,8 @@ export class LocalExporter {
 	}
 
 	private async validateTargetPath(targetPath: string): Promise<void> {
+		const base = contentBaseDir(this.settings);
+
 		try {
 			await fs.access(targetPath);
 		} catch {
@@ -159,29 +166,41 @@ export class LocalExporter {
 			throw new Error(`Target path does not exist: ${targetPath}`);
 		}
 
+		const expectedSiteDir = path.join(targetPath, base, "src", "site");
+
 		try {
-			await fs.access(path.join(targetPath, "src", "site"));
+			await fs.access(expectedSiteDir);
 		} catch {
+			const expectedRelative = base ? `${base}src/site/` : "src/site/";
+
 			new Notice(
-				"Folder doesn't look like a digital garden — expected src/site/ directory at " +
+				`Folder doesn't look like a digital garden — expected ${expectedRelative} directory at ` +
 					targetPath,
 			);
 			throw new Error(
-				`Target path missing src/site/ directory: ${targetPath}`,
+				`Target path missing ${expectedRelative} directory: ${targetPath}`,
 			);
 		}
 	}
 
 	private async writeEnvFile(targetPath: string): Promise<void> {
+		const base = contentBaseDir(this.settings);
 		const envValues = generateEnvValues(this.settings);
 		const envContent = serializeEnvValues(envValues);
 
-		await fs.writeFile(path.join(targetPath, ".env"), envContent, "utf-8");
+		await fs.writeFile(
+			path.join(targetPath, base, ".env"),
+			envContent,
+			"utf-8",
+		);
 	}
 
 	private async writeNavigationOrder(targetPath: string): Promise<void> {
+		const base = contentBaseDir(this.settings);
+
 		const navOrderPath = path.join(
 			targetPath,
+			base,
 			"src",
 			"site",
 			"_data",

--- a/src/models/IPublishPlatformConnection.ts
+++ b/src/models/IPublishPlatformConnection.ts
@@ -4,4 +4,5 @@ export interface IPublishPlatformConnection {
 	octoKit: Octokit;
 	userName: string;
 	pageName: string;
+	contentBaseDir?: string;
 }

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -90,4 +90,5 @@ export default interface DigitalGardenSettings {
 	devPluginPath?: string;
 	logLevel?: ILogLevel;
 	localExportPath?: string;
+	contentBaseDir?: string;
 }

--- a/src/publisher/Publisher.ts
+++ b/src/publisher/Publisher.ts
@@ -16,14 +16,12 @@ import { RepositoryConnection } from "../repositoryConnection/RepositoryConnecti
 import PublishPlatformConnectionFactory from "src/repositoryConnection/PublishPlatformConnectionFactory";
 import { PublishPlatform } from "../models/PublishPlatform";
 import { LimitReachedError } from "../forestry/LimitReachedError";
+import { imagePathBase, notePathBase, sitePath } from "./paths";
 
 export interface MarkedForPublishing {
 	notes: PublishFile[];
 	images: string[];
 }
-
-export const IMAGE_PATH_BASE = "src/site/img/user/";
-export const NOTE_PATH_BASE = "src/site/notes/";
 
 /**
  * Prepares files to be published and publishes them to Github
@@ -187,13 +185,13 @@ export default class Publisher {
 	}
 
 	async deleteNote(vaultFilePath: string, sha?: string) {
-		const path = `${NOTE_PATH_BASE}${vaultFilePath}`;
+		const path = notePathBase(this.settings) + vaultFilePath;
 
 		return await this.delete(path, sha);
 	}
 
 	async deleteImage(vaultFilePath: string, sha?: string) {
-		const path = `${IMAGE_PATH_BASE}${vaultFilePath}`;
+		const path = imagePathBase(this.settings) + vaultFilePath;
 
 		return await this.delete(path, sha);
 	}
@@ -352,12 +350,12 @@ export default class Publisher {
 
 	private async uploadText(filePath: string, content: string, sha?: string) {
 		content = Base64.encode(content);
-		const path = `${NOTE_PATH_BASE}${filePath}`;
+		const path = notePathBase(this.settings) + filePath;
 		await this.uploadToGithub(path, content, sha);
 	}
 
 	private async uploadImage(filePath: string, content: string, sha?: string) {
-		const path = `src/site${filePath}`;
+		const path = sitePath(this.settings, filePath);
 		await this.uploadToGithub(path, content, sha);
 	}
 

--- a/src/publisher/paths.ts
+++ b/src/publisher/paths.ts
@@ -1,0 +1,61 @@
+import type DigitalGardenSettings from "../models/settings";
+
+/**
+ * Un-prefixed suffixes describing the Eleventy garden template layout.
+ * These are relative to the (optional) {@link normalizeContentBaseDir content base directory}
+ * and are never used directly to build repo paths — always go through the builders below.
+ */
+export const NOTE_PATH_BASE = "src/site/notes/";
+export const IMAGE_PATH_BASE = "src/site/img/user/";
+
+/** Only the field the path builders actually depend on. */
+type ContentBaseSettings = Pick<DigitalGardenSettings, "contentBaseDir">;
+
+/**
+ * Normalize the configured content base directory into a repo-path prefix.
+ *
+ * - `undefined` / `""` / `"/"` → `""` (no prefix — the repo root, current behavior)
+ * - `"Web"` / `"/Web/"` / `"  Web  "` → `"Web/"`
+ * - `"a/b"` → `"a/b/"`
+ *
+ * The result never has a leading `/` and always ends with exactly one `/` when non-empty,
+ * so concatenating it with a suffix never produces `//` or a leading `/`.
+ */
+export function normalizeContentBaseDir(base?: string): string {
+	// Strip surrounding whitespace and all leading/trailing slashes, then re-append a
+	// single trailing slash. Empty, "/", "//" etc. collapse to "" (the repo root).
+	const stripped = (base ?? "")
+		.trim()
+		.replace(/^\/+/, "")
+		.replace(/\/+$/, "");
+
+	return stripped === "" ? "" : `${stripped}/`;
+}
+
+/** Normalized content base prefix derived from the settings (`""` or e.g. `"Web/"`). */
+export function contentBaseDir(settings: ContentBaseSettings): string {
+	return normalizeContentBaseDir(settings.contentBaseDir);
+}
+
+/** Repo path to the notes directory, e.g. `src/site/notes/` or `Web/src/site/notes/`. */
+export function notePathBase(settings: ContentBaseSettings): string {
+	return `${contentBaseDir(settings)}${NOTE_PATH_BASE}`;
+}
+
+/** Repo path to the user image directory, e.g. `src/site/img/user/`. */
+export function imagePathBase(settings: ContentBaseSettings): string {
+	return `${contentBaseDir(settings)}${IMAGE_PATH_BASE}`;
+}
+
+/**
+ * Repo path inside `src/site`, e.g. `sitePath(settings, "/logo.png")` → `src/site/logo.png`.
+ * `sub` is expected to begin with `/`.
+ */
+export function sitePath(settings: ContentBaseSettings, sub: string): string {
+	return `${contentBaseDir(settings)}src/site${sub}`;
+}
+
+/** Repo path to the garden `.env` file, e.g. `.env` or `Web/.env`. */
+export function envPath(settings: ContentBaseSettings): string {
+	return `${contentBaseDir(settings)}.env`;
+}

--- a/src/publisher/paths.ts
+++ b/src/publisher/paths.ts
@@ -1,4 +1,5 @@
 import type DigitalGardenSettings from "../models/settings";
+import { PublishPlatform } from "../models/PublishPlatform";
 
 /**
  * Un-prefixed suffixes describing the Eleventy garden template layout.
@@ -8,8 +9,11 @@ import type DigitalGardenSettings from "../models/settings";
 export const NOTE_PATH_BASE = "src/site/notes/";
 export const IMAGE_PATH_BASE = "src/site/img/user/";
 
-/** Only the field the path builders actually depend on. */
-type ContentBaseSettings = Pick<DigitalGardenSettings, "contentBaseDir">;
+/** Only the fields the path builders actually depend on. */
+type ContentBaseSettings = Pick<
+	DigitalGardenSettings,
+	"contentBaseDir" | "publishPlatform"
+>;
 
 /**
  * Normalize the configured content base directory into a repo-path prefix.
@@ -20,6 +24,9 @@ type ContentBaseSettings = Pick<DigitalGardenSettings, "contentBaseDir">;
  *
  * The result never has a leading `/` and always ends with exactly one `/` when non-empty,
  * so concatenating it with a suffix never produces `//` or a leading `/`.
+ *
+ * Values containing `.` or `..` segments are invalid (they could escape the target
+ * directory, e.g. in local export) and collapse to `""` (the repo root).
  */
 export function normalizeContentBaseDir(base?: string): string {
 	// Strip surrounding whitespace and all leading/trailing slashes, then re-append a
@@ -29,11 +36,34 @@ export function normalizeContentBaseDir(base?: string): string {
 		.replace(/^\/+/, "")
 		.replace(/\/+$/, "");
 
-	return stripped === "" ? "" : `${stripped}/`;
+	if (stripped === "") {
+		return "";
+	}
+
+	const segments = stripped.split("/");
+
+	if (segments.some((s) => s === "." || s === "..")) {
+		return "";
+	}
+
+	return `${stripped}/`;
 }
 
-/** Normalized content base prefix derived from the settings (`""` or e.g. `"Web/"`). */
+/**
+ * Normalized content base prefix derived from the settings (`""` or e.g. `"Web/"`).
+ *
+ * The setting only applies to self-hosted (GitHub) publishing — on managed platforms
+ * like Forestry the repository layout is fixed, so the base is ignored there. Local
+ * export is platform-independent and uses {@link normalizeContentBaseDir} directly.
+ */
 export function contentBaseDir(settings: ContentBaseSettings): string {
+	if (
+		settings.publishPlatform !== undefined &&
+		settings.publishPlatform !== PublishPlatform.SelfHosted
+	) {
+		return "";
+	}
+
 	return normalizeContentBaseDir(settings.contentBaseDir);
 }
 

--- a/src/repositoryConnection/DigitalGardenSiteManager.ts
+++ b/src/repositoryConnection/DigitalGardenSiteManager.ts
@@ -13,7 +13,7 @@ import {
 } from "./RepositoryConnection";
 import Logger from "js-logger";
 import { TemplateUpdateChecker } from "./TemplateManager";
-import { NOTE_PATH_BASE, IMAGE_PATH_BASE } from "../publisher/Publisher";
+import { envPath, imagePathBase, notePathBase } from "../publisher/paths";
 import PublishPlatformConnectionFactory from "./PublishPlatformConnectionFactory";
 import { PublishPlatform } from "src/models/PublishPlatform";
 import { generateEnvValues, serializeEnvValues } from "../utils/envSettings";
@@ -85,7 +85,7 @@ export default class DigitalGardenSiteManager {
 
 		const currentFile = await (
 			await this.getUserGardenConnection()
-		).getFile(".env");
+		).getFile(envPath(this.settings));
 
 		const decodedCurrentFile = Base64.decode(currentFile?.content ?? "");
 
@@ -125,7 +125,7 @@ export default class DigitalGardenSiteManager {
 		await (
 			await this.getUserGardenConnection()
 		).updateFile({
-			path: ".env",
+			path: envPath(this.settings),
 			content: base64Settings,
 			message: "Update settings",
 			sha: currentFile?.sha,
@@ -174,7 +174,7 @@ export default class DigitalGardenSiteManager {
 
 		const response = await (
 			await this.getUserGardenConnection()
-		).getFile(NOTE_PATH_BASE + path);
+		).getFile(notePathBase(this.settings) + path);
 
 		if (!response) {
 			return "";
@@ -189,18 +189,19 @@ export default class DigitalGardenSiteManager {
 		contentTree: NonNullable<TRepositoryContent>,
 	): Promise<Record<string, string>> {
 		const files = contentTree.tree;
+		const noteBase = notePathBase(this.settings);
 
 		const notes = files.filter(
 			(x): x is ContentTreeItem =>
 				typeof x.path === "string" &&
-				x.path.startsWith(NOTE_PATH_BASE) &&
+				x.path.startsWith(noteBase) &&
 				x.type === "blob" &&
-				x.path !== `${NOTE_PATH_BASE}notes.json`,
+				x.path !== `${noteBase}notes.json`,
 		);
 		const hashes: Record<string, string> = {};
 
 		for (const note of notes) {
-			const vaultPath = note.path.replace(NOTE_PATH_BASE, "");
+			const vaultPath = note.path.replace(noteBase, "");
 			hashes[vaultPath] = note.sha;
 		}
 
@@ -211,17 +212,18 @@ export default class DigitalGardenSiteManager {
 		contentTree: NonNullable<TRepositoryContent>,
 	): Promise<Record<string, string>> {
 		const files = contentTree.tree ?? [];
+		const imageBase = imagePathBase(this.settings);
 
 		const images = files.filter(
 			(x): x is ContentTreeItem =>
 				typeof x.path === "string" &&
-				x.path.startsWith(IMAGE_PATH_BASE) &&
+				x.path.startsWith(imageBase) &&
 				x.type === "blob",
 		);
 		const hashes: Record<string, string> = {};
 
 		for (const img of images) {
-			const vaultPath = img.path.replace(IMAGE_PATH_BASE, "");
+			const vaultPath = img.path.replace(imageBase, "");
 			hashes[vaultPath] = img.sha;
 		}
 

--- a/src/repositoryConnection/PublishPlatformConnectionFactory.ts
+++ b/src/repositoryConnection/PublishPlatformConnectionFactory.ts
@@ -28,6 +28,7 @@ export default class PublishPlatformConnectionFactory {
 				}),
 				userName: settings.githubUserName,
 				pageName: settings.githubRepo,
+				contentBaseDir: settings.contentBaseDir,
 			};
 		} else if (settings.publishPlatform === PublishPlatform.ForestryMd) {
 			const userName = "Forestry";

--- a/src/repositoryConnection/RepositoryConnection.ts
+++ b/src/repositoryConnection/RepositoryConnection.ts
@@ -36,6 +36,11 @@ export class RepositoryConnection {
 		this.octokit = octoKit;
 	}
 
+	/** Normalized content base prefix (`""` or e.g. `"Web/"`) this connection publishes under. */
+	get contentBaseDir(): string {
+		return this.contentBase;
+	}
+
 	getRepositoryName() {
 		return this.userName + "/" + this.pageName;
 	}

--- a/src/repositoryConnection/RepositoryConnection.ts
+++ b/src/repositoryConnection/RepositoryConnection.ts
@@ -3,6 +3,7 @@ import Logger from "js-logger";
 import { CompiledPublishFile } from "src/publishFile/PublishFile";
 import { IPublishPlatformConnection } from "src/models/IPublishPlatformConnection";
 import { throwIfLimitError } from "src/forestry/LimitReachedError";
+import { normalizeContentBaseDir } from "src/publisher/paths";
 
 const logger = Logger.get("repository-connection");
 
@@ -20,11 +21,18 @@ interface IPutPayload {
 export class RepositoryConnection {
 	private userName: string;
 	private pageName: string;
+	private contentBase: string;
 	octokit: Octokit;
 
-	constructor({ octoKit, userName, pageName }: IPublishPlatformConnection) {
+	constructor({
+		octoKit,
+		userName,
+		pageName,
+		contentBaseDir,
+	}: IPublishPlatformConnection) {
 		this.pageName = pageName;
 		this.userName = userName;
+		this.contentBase = normalizeContentBaseDir(contentBaseDir);
 		this.octokit = octoKit;
 	}
 
@@ -208,10 +216,14 @@ export class RepositoryConnection {
 
 		const filesToDelete = filePaths.map((path) => {
 			if (path.endsWith(".md")) {
-				return `${NOTE_PATH_BASE}${normalizePath(path)}`;
+				return `${this.contentBase}${NOTE_PATH_BASE}${normalizePath(
+					path,
+				)}`;
 			}
 
-			return `${IMAGE_PATH_BASE}${normalizePath(path)}`;
+			return `${this.contentBase}${IMAGE_PATH_BASE}${normalizePath(
+				path,
+			)}`;
 		});
 
 		const repoDataPromise = this.octokit.request(
@@ -321,7 +333,9 @@ export class RepositoryConnection {
 				);
 
 				return {
-					path: `${NOTE_PATH_BASE}${normalizePath(file.getPath())}`,
+					path: `${this.contentBase}${NOTE_PATH_BASE}${normalizePath(
+						file.getPath(),
+					)}`,
 					mode: "100644",
 					type: "blob",
 					sha: blob.data.sha,
@@ -366,7 +380,9 @@ export class RepositoryConnection {
 				);
 
 				return {
-					path: `${IMAGE_PATH_BASE}${normalizePath(asset.path)}`,
+					path: `${this.contentBase}${IMAGE_PATH_BASE}${normalizePath(
+						asset.path,
+					)}`,
 					mode: "100644",
 					type: "blob",
 					sha: blob.data.sha,

--- a/src/repositoryConnection/TemplateManager.ts
+++ b/src/repositoryConnection/TemplateManager.ts
@@ -54,6 +54,16 @@ export class TemplateUpdateChecker {
 		return file;
 	}
 
+	/**
+	 * Template file paths (from plugin-info.json) are relative to the template root.
+	 * In the user's repo the template may live under a content base directory, so
+	 * lookups and writes there must be prefixed. IUpdateFileInfo paths stay
+	 * template-relative; the prefix is applied at the user-repo boundary only.
+	 */
+	private get userContentBase(): string {
+		return this.userGardenConnection.contentBaseDir;
+	}
+
 	private getFilesToDelete(
 		pluginInfo: DigitalGardenPluginInfo,
 		userFileList: NonNullable<TRepositoryContent>,
@@ -61,7 +71,10 @@ export class TemplateUpdateChecker {
 		const filesToDelete = [];
 
 		for (const file of pluginInfo.filesToDelete) {
-			const currentFile = this.getFileInfoFromContent(userFileList, file);
+			const currentFile = this.getFileInfoFromContent(
+				userFileList,
+				this.userContentBase + file,
+			);
 
 			if (currentFile) {
 				filesToDelete.push({ path: file, sha: currentFile.sha });
@@ -78,7 +91,10 @@ export class TemplateUpdateChecker {
 		const filesToUpdate = [];
 
 		for (const file of pluginInfo.filesToModify) {
-			const currentFile = this.getFileInfoFromContent(userFileList, file);
+			const currentFile = this.getFileInfoFromContent(
+				userFileList,
+				this.userContentBase + file,
+			);
 
 			const baseFile = this.getFileInfoFromContent(
 				baseGardenFileList,
@@ -100,7 +116,10 @@ export class TemplateUpdateChecker {
 		const filesToAdd = [];
 
 		for (const file of pluginInfo.filesToAdd) {
-			const currentFile = this.getFileInfoFromContent(userFileList, file);
+			const currentFile = this.getFileInfoFromContent(
+				userFileList,
+				this.userContentBase + file,
+			);
 
 			if (!currentFile) {
 				filesToAdd.push({ path: file });
@@ -312,10 +331,13 @@ export class TemplateUpdater {
 		branch: string,
 	) {
 		for (const file of filesToDelete) {
-			await this.userGardenConnection.deleteFile(file.path, {
-				branch,
-				sha: file.sha,
-			});
+			await this.userGardenConnection.deleteFile(
+				this.userGardenConnection.contentBaseDir + file.path,
+				{
+					branch,
+					sha: file.sha,
+				},
+			);
 		}
 	}
 
@@ -324,6 +346,8 @@ export class TemplateUpdater {
 		branch: string,
 	) {
 		for (const file of filesToAdd) {
+			// Content comes from the base template repo (template-relative path),
+			// but lands in the user's repo under its content base directory.
 			const baseTemplateFile = await this.baseGardenConnection.getFile(
 				file.path,
 			);
@@ -334,7 +358,7 @@ export class TemplateUpdater {
 
 			await this.userGardenConnection.updateFile({
 				content: baseTemplateFile.content,
-				path: file.path,
+				path: this.userGardenConnection.contentBaseDir + file.path,
 				branch: branch,
 				sha: file.sha,
 				message: "Update files",

--- a/src/test/DigitalGardenSiteManager.test.ts
+++ b/src/test/DigitalGardenSiteManager.test.ts
@@ -1,0 +1,72 @@
+import { MetadataCache } from "obsidian";
+import DigitalGardenSiteManager from "../repositoryConnection/DigitalGardenSiteManager";
+import DigitalGardenSettings from "../models/settings";
+import { TRepositoryContent } from "../repositoryConnection/RepositoryConnection";
+
+jest.mock("obsidian");
+
+const makeSettings = (contentBaseDir: string): DigitalGardenSettings =>
+	({
+		pathRewriteRules: "",
+		contentBaseDir,
+	}) as DigitalGardenSettings;
+
+const makeTree = (base: string): NonNullable<TRepositoryContent> =>
+	({
+		tree: [
+			{
+				path: `${base}src/site/notes/note.md`,
+				sha: "note-sha",
+				type: "blob",
+			},
+			{
+				path: `${base}src/site/notes/notes.json`,
+				sha: "json-sha",
+				type: "blob",
+			},
+			{
+				path: `${base}src/site/img/user/pic.png`,
+				sha: "img-sha",
+				type: "blob",
+			},
+			// Files outside the garden base must be ignored.
+			{ path: `README.md`, sha: "readme-sha", type: "blob" },
+			{ path: `other/src/site/notes/x.md`, sha: "x-sha", type: "blob" },
+		],
+	}) as unknown as NonNullable<TRepositoryContent>;
+
+describe("DigitalGardenSiteManager base stripping", () => {
+	const makeManager = (contentBaseDir: string) =>
+		new DigitalGardenSiteManager(
+			{} as MetadataCache,
+			makeSettings(contentBaseDir),
+		);
+
+	describe.each([
+		{ label: "no base (repo root)", base: "" },
+		{ label: "Web subfolder", base: "Web/" },
+	])("$label", ({ base }) => {
+		it("strips the base from note hashes and skips notes.json", async () => {
+			const manager = makeManager(base.replace(/\/$/, ""));
+			const hashes = await manager.getNoteHashes(makeTree(base));
+
+			expect(hashes).toEqual({ "note.md": "note-sha" });
+			expect(hashes["notes.json"]).toBeUndefined();
+		});
+
+		it("strips the base from image hashes", async () => {
+			const manager = makeManager(base.replace(/\/$/, ""));
+			const hashes = await manager.getImageHashes(makeTree(base));
+
+			expect(hashes).toEqual({ "pic.png": "img-sha" });
+		});
+	});
+
+	it("does not pick up files that share the suffix under a different base", async () => {
+		// A repo-root garden must not treat `other/src/site/...` as its own.
+		const manager = makeManager("");
+		const hashes = await manager.getNoteHashes(makeTree(""));
+
+		expect(Object.keys(hashes)).toEqual(["note.md"]);
+	});
+});

--- a/src/test/TemplateManager.test.ts
+++ b/src/test/TemplateManager.test.ts
@@ -1,0 +1,170 @@
+import { Base64 } from "js-base64";
+import {
+	TemplateUpdateChecker,
+	TemplateUpdater,
+} from "../repositoryConnection/TemplateManager";
+import { RepositoryConnection } from "../repositoryConnection/RepositoryConnection";
+import { Octokit } from "@octokit/core";
+
+const PLUGIN_INFO = {
+	filesToAdd: ["src/site/new.njk"],
+	filesToModify: ["package.json"],
+	filesToDelete: ["old.js"],
+};
+
+const BASE_TREE = {
+	tree: [
+		{ path: "package.json", sha: "pkg-sha", type: "blob" },
+		{ path: "src/site/new.njk", sha: "new-sha", type: "blob" },
+	],
+};
+
+interface ITreeItem {
+	path: string;
+	sha: string;
+	type: string;
+}
+
+const makeBaseConnection = (getFileCalls: string[] = []) =>
+	({
+		getFile: async (path: string) => {
+			getFileCalls.push(path);
+
+			if (path === "plugin-info.json") {
+				return {
+					content: Base64.encode(JSON.stringify(PLUGIN_INFO)),
+				};
+			}
+
+			return { content: Base64.encode("template file content") };
+		},
+		getContent: async () => BASE_TREE,
+		getRepositoryInfo: async () => ({ default_branch: "main" }),
+	}) as unknown as RepositoryConnection;
+
+const makeUserConnection = (contentBaseDir: string, tree: ITreeItem[]) =>
+	({
+		contentBaseDir,
+		getContent: async () => ({ tree }),
+	}) as unknown as RepositoryConnection;
+
+describe("RepositoryConnection.contentBaseDir", () => {
+	const octoKit = {} as Octokit;
+
+	it("exposes the normalized base", () => {
+		const connection = new RepositoryConnection({
+			octoKit,
+			userName: "user",
+			pageName: "repo",
+			contentBaseDir: "Web",
+		});
+
+		expect(connection.contentBaseDir).toBe("Web/");
+	});
+
+	it("is empty when unset", () => {
+		const connection = new RepositoryConnection({
+			octoKit,
+			userName: "user",
+			pageName: "repo",
+		});
+
+		expect(connection.contentBaseDir).toBe("");
+	});
+});
+
+describe("TemplateUpdateChecker with a content base directory", () => {
+	const upToDateTree = (base: string): ITreeItem[] => [
+		{ path: `${base}package.json`, sha: "pkg-sha", type: "blob" },
+		{ path: `${base}src/site/new.njk`, sha: "new-sha", type: "blob" },
+	];
+
+	it.each([
+		{ label: "repo root", base: "" },
+		{ label: "Web subfolder", base: "Web/" },
+	])(
+		"reports no updates when template files under the base match ($label)",
+		async ({ base }) => {
+			const checker = new TemplateUpdateChecker({
+				baseGardenConnection: makeBaseConnection(),
+				userGardenConnection: makeUserConnection(
+					base,
+					upToDateTree(base),
+				),
+			});
+
+			expect(await checker.getFilesToUpdate()).toBeNull();
+		},
+	);
+
+	it("diffs template files at the prefixed path, keeping template-relative paths", async () => {
+		const userTree: ITreeItem[] = [
+			// Outdated copy of a template file, plus a file slated for deletion.
+			{ path: "Web/package.json", sha: "outdated-sha", type: "blob" },
+			{ path: "Web/old.js", sha: "old-sha", type: "blob" },
+			// A root-level file matching the template path must not count.
+			{ path: "package.json", sha: "pkg-sha", type: "blob" },
+		];
+
+		const checker = new TemplateUpdateChecker({
+			baseGardenConnection: makeBaseConnection(),
+			userGardenConnection: makeUserConnection("Web/", userTree),
+		});
+
+		const updateInfo = await checker.getFilesToUpdate();
+
+		expect(updateInfo).toEqual({
+			filesToDelete: [{ path: "old.js", sha: "old-sha" }],
+			filesToUpdate: [{ path: "package.json", sha: "outdated-sha" }],
+			filesToAdd: [{ path: "src/site/new.njk" }],
+		});
+	});
+});
+
+describe("TemplateUpdater with a content base directory", () => {
+	it("reads from the template root but writes to the prefixed path", async () => {
+		const baseGetFileCalls: string[] = [];
+		const deletedPaths: string[] = [];
+		const updatedPaths: string[] = [];
+
+		const userGardenConnection = {
+			contentBaseDir: "Web/",
+			getLatestCommit: async () => ({ sha: "commit-sha" }),
+			createBranch: async () => undefined,
+			deleteFile: async (path: string) => {
+				deletedPaths.push(path);
+
+				return true;
+			},
+			updateFile: async ({ path }: { path: string }) => {
+				updatedPaths.push(path);
+			},
+			getBasePayload: () => ({ owner: "user", repo: "repo" }),
+			octokit: {
+				request: async () => ({ data: { html_url: "pr-url" } }),
+			},
+		} as unknown as RepositoryConnection;
+
+		const updater = new TemplateUpdater({
+			baseGardenConnection: makeBaseConnection(baseGetFileCalls),
+			userGardenConnection,
+			defaultBranch: "main",
+			newestTemplateVersion: "1.0.0",
+			filesToChange: {
+				filesToDelete: [{ path: "old.js", sha: "old-sha" }],
+				filesToUpdate: [{ path: "package.json", sha: "outdated-sha" }],
+				filesToAdd: [{ path: "src/site/new.njk" }],
+			},
+		});
+
+		await updater.updateTemplate();
+
+		expect(deletedPaths).toEqual(["Web/old.js"]);
+		expect(updatedPaths).toContain("Web/package.json");
+		expect(updatedPaths).toContain("Web/src/site/new.njk");
+		// Content is always fetched from the base template repo at the template-relative path.
+		expect(baseGetFileCalls).toContain("package.json");
+		expect(baseGetFileCalls).toContain("src/site/new.njk");
+		expect(baseGetFileCalls).not.toContain("Web/package.json");
+	});
+});

--- a/src/test/paths.test.ts
+++ b/src/test/paths.test.ts
@@ -1,0 +1,126 @@
+import DigitalGardenSettings from "../models/settings";
+import {
+	NOTE_PATH_BASE,
+	IMAGE_PATH_BASE,
+	normalizeContentBaseDir,
+	contentBaseDir,
+	notePathBase,
+	imagePathBase,
+	sitePath,
+	envPath,
+} from "../publisher/paths";
+
+const withBase = (contentBase?: string) =>
+	({ contentBaseDir: contentBase }) as DigitalGardenSettings;
+
+describe("paths", () => {
+	describe("normalizeContentBaseDir", () => {
+		const CASES: Array<{ input: string | undefined; expected: string }> = [
+			{ input: undefined, expected: "" },
+			{ input: "", expected: "" },
+			{ input: "   ", expected: "" },
+			{ input: "/", expected: "" },
+			{ input: "//", expected: "" },
+			{ input: "Web", expected: "Web/" },
+			{ input: "Web/", expected: "Web/" },
+			{ input: "/Web", expected: "Web/" },
+			{ input: "/Web/", expected: "Web/" },
+			{ input: "  Web  ", expected: "Web/" },
+			{ input: "a/b", expected: "a/b/" },
+			{ input: "/a/b/", expected: "a/b/" },
+		];
+
+		it.each(CASES)(
+			"normalizes $input -> $expected",
+			({ input, expected }) => {
+				expect(normalizeContentBaseDir(input)).toBe(expected);
+			},
+		);
+
+		it("never emits a leading slash or a double slash", () => {
+			for (const { input } of CASES) {
+				const result = normalizeContentBaseDir(input);
+				expect(result.startsWith("/")).toBe(false);
+				expect(result.includes("//")).toBe(false);
+			}
+		});
+	});
+
+	describe("path builders — backward compatibility (empty base)", () => {
+		const settings = withBase("");
+
+		it("contentBaseDir is empty", () => {
+			expect(contentBaseDir(settings)).toBe("");
+		});
+
+		it("notePathBase equals the historical literal", () => {
+			expect(notePathBase(settings)).toBe("src/site/notes/");
+			expect(notePathBase(settings)).toBe(NOTE_PATH_BASE);
+		});
+
+		it("imagePathBase equals the historical literal", () => {
+			expect(imagePathBase(settings)).toBe("src/site/img/user/");
+			expect(imagePathBase(settings)).toBe(IMAGE_PATH_BASE);
+		});
+
+		it("sitePath equals the historical literal", () => {
+			expect(sitePath(settings, "/favicon.svg")).toBe(
+				"src/site/favicon.svg",
+			);
+
+			expect(sitePath(settings, "/img/user/a.png")).toBe(
+				"src/site/img/user/a.png",
+			);
+		});
+
+		it("envPath equals the historical literal", () => {
+			expect(envPath(settings)).toBe(".env");
+		});
+
+		it("matches for undefined contentBaseDir too", () => {
+			const undefinedSettings = withBase(undefined);
+			expect(notePathBase(undefinedSettings)).toBe("src/site/notes/");
+			expect(imagePathBase(undefinedSettings)).toBe("src/site/img/user/");
+			expect(envPath(undefinedSettings)).toBe(".env");
+		});
+	});
+
+	describe("path builders — with a base directory", () => {
+		it.each(["Web", "Web/", "/Web/"])(
+			"prefixes every path with %s -> Web/",
+			(base) => {
+				const settings = withBase(base);
+				expect(notePathBase(settings)).toBe("Web/src/site/notes/");
+				expect(imagePathBase(settings)).toBe("Web/src/site/img/user/");
+
+				expect(sitePath(settings, "/favicon.svg")).toBe(
+					"Web/src/site/favicon.svg",
+				);
+				expect(envPath(settings)).toBe("Web/.env");
+			},
+		);
+
+		it("supports nested base directories", () => {
+			const settings = withBase("a/b");
+			expect(notePathBase(settings)).toBe("a/b/src/site/notes/");
+			expect(imagePathBase(settings)).toBe("a/b/src/site/img/user/");
+			expect(envPath(settings)).toBe("a/b/.env");
+		});
+
+		it("never produces a leading slash or a double slash", () => {
+			const settings = withBase("/Web/");
+
+			const produced = [
+				notePathBase(settings),
+				imagePathBase(settings),
+				sitePath(settings, "/logo.png"),
+				envPath(settings),
+			];
+
+			for (const p of produced) {
+				expect(p.startsWith("/")).toBe(false);
+				expect(p.includes("//")).toBe(false);
+			}
+		});
+	});
+});

--- a/src/test/paths.test.ts
+++ b/src/test/paths.test.ts
@@ -1,4 +1,5 @@
 import DigitalGardenSettings from "../models/settings";
+import { PublishPlatform } from "../models/PublishPlatform";
 import {
 	NOTE_PATH_BASE,
 	IMAGE_PATH_BASE,
@@ -28,6 +29,12 @@ describe("paths", () => {
 			{ input: "  Web  ", expected: "Web/" },
 			{ input: "a/b", expected: "a/b/" },
 			{ input: "/a/b/", expected: "a/b/" },
+			// Traversal or relative segments are invalid — fall back to the repo root.
+			{ input: "..", expected: "" },
+			{ input: "../escape", expected: "" },
+			{ input: "a/../b", expected: "" },
+			{ input: ".", expected: "" },
+			{ input: "a/./b", expected: "" },
 		];
 
 		it.each(CASES)(
@@ -121,6 +128,37 @@ describe("paths", () => {
 				expect(p.startsWith("/")).toBe(false);
 				expect(p.includes("//")).toBe(false);
 			}
+		});
+	});
+
+	describe("path builders — publish platform gating", () => {
+		const withPlatform = (
+			contentBase: string,
+			publishPlatform: PublishPlatform,
+		) =>
+			({
+				contentBaseDir: contentBase,
+				publishPlatform,
+			}) as DigitalGardenSettings;
+
+		it("ignores contentBaseDir on the Forestry platform", () => {
+			const settings = withPlatform("Web", PublishPlatform.ForestryMd);
+
+			expect(contentBaseDir(settings)).toBe("");
+			expect(notePathBase(settings)).toBe("src/site/notes/");
+			expect(imagePathBase(settings)).toBe("src/site/img/user/");
+
+			expect(sitePath(settings, "/favicon.svg")).toBe(
+				"src/site/favicon.svg",
+			);
+			expect(envPath(settings)).toBe(".env");
+		});
+
+		it("applies contentBaseDir on the self-hosted (GitHub) platform", () => {
+			const settings = withPlatform("Web", PublishPlatform.SelfHosted);
+
+			expect(notePathBase(settings)).toBe("Web/src/site/notes/");
+			expect(envPath(settings)).toBe("Web/.env");
 		});
 	});
 });

--- a/src/views/NavigationOrder/NavigationOrderView.svelte
+++ b/src/views/NavigationOrder/NavigationOrderView.svelte
@@ -6,6 +6,7 @@
 	import type Publisher from "../../publisher/Publisher";
 	import type DigitalGardenSettings from "../../models/settings";
 	import { getGardenPathForNote, getRewriteRules } from "../../utils/utils";
+	import { sitePath } from "../../publisher/paths";
 	import SortableTree from "./SortableTree.svelte";
 
 	export let repositoryConnection: RepositoryConnection;
@@ -28,7 +29,7 @@
 	let tree: TreeItem[] = [];
 	let remoteSha: string | null = null;
 
-	const NAV_ORDER_PATH = "src/site/_data/navigationOrder.json";
+	const NAV_ORDER_PATH = sitePath(settings, "/_data/navigationOrder.json");
 
 	onMount(async () => {
 		await loadTree();

--- a/src/views/SettingsView/GithubSettings.ts
+++ b/src/views/SettingsView/GithubSettings.ts
@@ -24,6 +24,7 @@ export class GithubSettings {
 		this.initializeGitHubRepoSetting();
 		this.initializeGitHubUserNameSetting();
 		this.initializeGitHubTokenSetting();
+		this.initializeContentBaseDirSetting();
 	}
 
 	initializeHeader = () => {
@@ -246,6 +247,23 @@ export class GithubSettings {
 					.setValue(this.settings.settings.githubToken)
 					.onChange(async (value) => {
 						this.settings.settings.githubToken = value;
+						await this.checkConnectionAndSaveSettings();
+					}),
+			);
+	}
+
+	private initializeContentBaseDirSetting() {
+		new Setting(this.settingsRootElement)
+			.setName("Content base directory (advanced)")
+			.setDesc(
+				"Subdirectory inside your repository where the digital garden template lives (e.g. Web). Leave empty if the template is at the repo root. Affects GitHub publishing, remote settings, and local export.",
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder("Web")
+					.setValue(this.settings.settings.contentBaseDir ?? "")
+					.onChange(async (value) => {
+						this.settings.settings.contentBaseDir = value;
 						await this.checkConnectionAndSaveSettings();
 					}),
 			);

--- a/src/views/SettingsView/SettingView.ts
+++ b/src/views/SettingsView/SettingView.ts
@@ -19,6 +19,7 @@ import { Base64 } from "js-base64";
 
 import DigitalGardenSettings from "../../models/settings";
 import Publisher from "../../publisher/Publisher";
+import { envPath } from "../../publisher/paths";
 import { arrayBufferToBase64 } from "../../utils/utils";
 import {
 	ImageFileSuggest,
@@ -366,7 +367,10 @@ export default class SettingView {
 
 				const connection =
 					await gardenManager.getUserGardenConnection();
-				const envFile = await connection.getFile(".env");
+
+				const envFile = await connection.getFile(
+					envPath(this.settings),
+				);
 
 				if (envFile?.content) {
 					const envContent = Base64.decode(envFile.content);
@@ -738,7 +742,10 @@ export default class SettingView {
 
 				const connection =
 					await gardenManager.getUserGardenConnection();
-				const envFile = await connection.getFile(".env");
+
+				const envFile = await connection.getFile(
+					envPath(this.settings),
+				);
 
 				if (envFile?.content) {
 					const envContent = Base64.decode(envFile.content);
@@ -1151,7 +1158,10 @@ export default class SettingView {
 
 				const connection =
 					await gardenManager.getUserGardenConnection();
-				const envFile = await connection.getFile(".env");
+
+				const envFile = await connection.getFile(
+					envPath(this.settings),
+				);
 
 				if (envFile?.content) {
 					const envContent = Base64.decode(envFile.content);

--- a/src/views/SettingsView/SettingView.ts
+++ b/src/views/SettingsView/SettingView.ts
@@ -19,7 +19,7 @@ import { Base64 } from "js-base64";
 
 import DigitalGardenSettings from "../../models/settings";
 import Publisher from "../../publisher/Publisher";
-import { envPath } from "../../publisher/paths";
+import { envPath, sitePath } from "../../publisher/paths";
 import { arrayBufferToBase64 } from "../../utils/utils";
 import {
 	ImageFileSuggest,
@@ -1911,7 +1911,7 @@ export default class SettingView {
 				{
 					owner,
 					repo,
-					path: "src/site/favicon.svg",
+					path: sitePath(this.settings, "/favicon.svg"),
 				},
 			);
 
@@ -1934,7 +1934,7 @@ export default class SettingView {
 			await octokit.request("PUT /repos/{owner}/{repo}/contents/{path}", {
 				owner,
 				repo,
-				path: "src/site/favicon.svg",
+				path: sitePath(this.settings, "/favicon.svg"),
 				message: `Update favicon.svg`,
 				content: base64SettingsFaviconContent,
 				// @ts-expect-error TODO: abstract octokit response
@@ -1947,7 +1947,7 @@ export default class SettingView {
 		Logger.info(
 			`addLogo called, logoPath setting: "${this.settings.logoPath}", owner: "${owner}", repo: "${repo}"`,
 		);
-		const logoBasePath = "src/site/logo";
+		const logoBasePath = sitePath(this.settings, "/logo");
 
 		// First, try to delete any existing logo files
 		const logoExtensions = ["png", "jpg", "jpeg", "gif", "svg", "webp"];


### PR DESCRIPTION
## Summary

Adds an optional **`contentBaseDir`** setting that lets the plugin publish the digital garden into a **subdirectory of the target repository** (e.g. `Web/`) instead of assuming the Eleventy template lives at the repo root.

When empty (the default), **every produced path is byte-for-byte identical to today** — existing users see zero change.

## Motivation

The plugin currently hardcodes the garden location to the repository root: notes go to `src/site/notes/`, images to `src/site/img/user/`, settings to a root `.env`. This breaks **monorepo layouts** where the Eleventy garden template lives in a subfolder (e.g. `Web/`):

- GitHub **Publish** writes to `src/site/notes/`, but the site builds from `Web/src/site/notes/` → nothing shows up.
- **"Load remote settings"** reads the root `.env` → 404 → *"Could not load remote settings"*.

The **local export** feature already effectively supported an arbitrary target path; this change brings **parity to the GitHub publish flow** and the remote-settings flow.

## The setting

`contentBaseDir?: string` — the path **within the repo** where the garden template root lives. Default unset/`""`.

| Setting             | Notes are written to  | Settings file |
| ------------------- | --------------------- | ------------- |
| _(empty)_ (default) | `src/site/notes/`     | `.env`        |
| `Web`               | `Web/src/site/notes/` | `Web/.env`    |

## Changes

**New helper — `src/publisher/paths.ts`**
- `normalizeContentBaseDir()` + path builders `notePathBase` / `imagePathBase` / `sitePath` / `envPath` that take `settings` instead of module-level consts.

**Wiring**
- `Publisher.ts` — routes note/image/site/delete paths through the builders.
- `RepositoryConnection.ts` — the primary **batch publish** path (`updateFiles`) and `deleteFiles` now prefix the base, threaded via `IPublishPlatformConnection` → `PublishPlatformConnectionFactory`.
- `DigitalGardenSiteManager.ts` — `.env` read/write and the remote note/image hash **diffing** strip the base consistently, so computed vault paths are unchanged when the base is empty.
- `LocalExporter.ts` — applies the base relative to `targetPath` for notes/images/favicon/logo/`.env`/nav-order; `validateTargetPath` checks `<base>/src/site` and names it in the error.
- Settings: `contentBaseDir` added to the interface + defaults.

**UI**
- New **"Content base directory (advanced)"** text field in the GitHub settings.

## Backward compatibility

- With `contentBaseDir` empty/undefined, all paths equal the current string literals (asserted by unit tests).

## Local export note

When `contentBaseDir` is set, point **Local garden folder path** at the **repo root** (the folder that contains `<base>/src/site`), not the subfolder — otherwise paths would double-nest. This is documented in the setting description and README.

## Tests

- `src/test/paths.test.ts` — normalization + builders for `""`, `"Web"`, `"/Web/"`, `"a/b"`; explicitly asserts **default equals the current literals**.
- `src/test/DigitalGardenSiteManager.test.ts` — remote note/image hash diffing strips the base correctly for both `""` and `Web/`, skips `notes.json`, and ignores same-suffix files under a different base.
- `jest.config.js` — added a `moduleNameMapper` mirroring the tsconfig `baseUrl` so the repo's `src/…` absolute imports resolve under jest (needed to test `RepositoryConnection`).

All checks green:

```
npm run lint    # clean
npm test        # 73 passed, 73 total
npm run build   # ok
```

## Docs

- New **"Publishing into a subfolder / monorepo"** section in `README.md`.