### PR TITLE
fix: restore Svelte components stripped from the 2.80.0 bundle

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -33,7 +33,12 @@ esbuild.build({
 	plugins: [
 		esbuildSvelte({
 		  compilerOptions: { css: 'injected'},
-		  preprocess: sveltePreprocess(),
+		  // verbatimModuleSyntax is required by svelte-preprocess v6: without it
+		  // the TS transpile strips component imports that are only used in
+		  // markup, leaving undefined references in the bundle.
+		  preprocess: sveltePreprocess({
+		    typescript: { compilerOptions: { verbatimModuleSyntax: true } },
+		  }),
 		}),
 	],
 	define: {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "node esbuild.config.mjs",
 		"postdev": "node scripts/generateGardenSettings.mjs",
 		"dev1": "parcel main.ts",
-		"build": "node esbuild.config.mjs production",
+		"build": "node esbuild.config.mjs production && node scripts/verifyBundle.mjs",
 		"test": "jest",
 		"prepare": "husky install",
 		"lint": "eslint . --ext .ts --ext .svelte",

--- a/scripts/verifyBundle.mjs
+++ b/scripts/verifyBundle.mjs
@@ -1,0 +1,66 @@
+// Guards against Svelte components silently missing from the bundle.
+// svelte-preprocess/TS can strip component imports that are only used in
+// markup (see the 2.80.0 "Tutorial is not defined" bug); esbuild then emits
+// calls to undefined identifiers without failing the build. Every bundled
+// module gets a `// <path>` comment in the (unminified) output, so we assert
+// one exists for each .svelte file that is imported somewhere in the source.
+import fs from "fs";
+import path from "path";
+
+const bundlePath = process.argv[2] ?? "main.js";
+const bundle = fs.readFileSync(bundlePath, "utf8");
+
+const sourceFiles = [];
+
+const walk = (dir) => {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+
+		if (entry.isDirectory()) {
+			if (entry.name === "dg-testVault") continue;
+			walk(full);
+		} else if (/\.(ts|svelte)$/.test(entry.name)) {
+			sourceFiles.push(full);
+		}
+	}
+};
+walk("src");
+sourceFiles.push("main.ts");
+
+const importedSveltePaths = new Set();
+
+for (const file of sourceFiles) {
+	// Imports from files that were themselves tree-shaken away (dead code)
+	// don't need to be in the bundle.
+	const importerBundled =
+		file === "main.ts" || bundle.includes(`// ${path.normalize(file)}`);
+
+	if (!importerBundled) continue;
+
+	const content = fs.readFileSync(file, "utf8");
+
+	for (const match of content.matchAll(/from\s+["']([^"']+\.svelte)["']/g)) {
+		const spec = match[1];
+
+		const resolved = spec.startsWith(".")
+			? path.join(path.dirname(file), spec)
+			: spec; // tsconfig-style "src/..." absolute import
+		importedSveltePaths.add(path.normalize(resolved));
+	}
+}
+
+const missing = [...importedSveltePaths].filter(
+	(sveltePath) => !bundle.includes(`// ${sveltePath}`),
+);
+
+if (missing.length > 0) {
+	console.error(
+		`Bundle verification FAILED — imported Svelte components missing from ${bundlePath}:`,
+	);
+	missing.forEach((m) => console.error(`  - ${m}`));
+	process.exit(1);
+}
+
+console.log(
+	`Bundle verification OK — ${importedSveltePaths.size} Svelte components present in ${bundlePath}`,
+);

--- a/src/views/PublicationCenterView/DiffPane.svelte
+++ b/src/views/PublicationCenterView/DiffPane.svelte
@@ -3,7 +3,7 @@
 	import { createEventDispatcher } from "svelte";
 	import * as Diff from "diff";
 	import Icon from "../../ui/Icon.svelte";
-	import { FileStatus } from "./annotate";
+	import type { FileStatus } from "./annotate";
 	import UnifiedDiff from "./UnifiedDiff.svelte";
 	import SplitDiff from "./SplitDiff.svelte";
 

--- a/src/views/PublicationCenterView/FileTree.svelte
+++ b/src/views/PublicationCenterView/FileTree.svelte
@@ -1,6 +1,6 @@
 <!-- src/views/PublicationCenterView/FileTree.svelte -->
 <script lang="ts">
-	import { FileTreeNode } from "./fileTree";
+	import type { FileTreeNode } from "./fileTree";
 	import Node from "./FileTreeNode.svelte";
 
 	export let node: FileTreeNode;

--- a/src/views/PublicationCenterView/FileTreeNode.svelte
+++ b/src/views/PublicationCenterView/FileTreeNode.svelte
@@ -6,7 +6,8 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
 	import Icon from "../../ui/Icon.svelte";
-	import { FileTreeNode, collectFilePaths } from "./fileTree";
+	import { collectFilePaths } from "./fileTree";
+	import type { FileTreeNode } from "./fileTree";
 
 	export let node: FileTreeNode;
 	export let selected: Set<string>;

--- a/src/views/PublicationCenterView/PublicationCenter.svelte
+++ b/src/views/PublicationCenterView/PublicationCenter.svelte
@@ -5,17 +5,16 @@
 	import { LimitReachedError } from "../../forestry/LimitReachedError";
 	import { notifyLimitReached } from "../../forestry/limitNotice";
 	import DigitalGardenSiteManager from "../../repositoryConnection/DigitalGardenSiteManager";
-	import {
+	import type {
 		IPublishStatusManager,
 		PublishStatus,
 	} from "../../publisher/PublishStatusManager";
 	import {
 		annotateFiles,
 		defaultSelection,
-		AnnotatedFile,
-		FileStatus,
 		buildPublishPlan,
 	} from "./annotate";
+	import type { AnnotatedFile, FileStatus } from "./annotate";
 	import { buildFileTree, filterTree } from "./fileTree";
 	import * as Diff from "diff";
 	import StatusFilters from "./StatusFilters.svelte";

--- a/src/views/PublicationCenterView/StatusFilters.svelte
+++ b/src/views/PublicationCenterView/StatusFilters.svelte
@@ -1,7 +1,7 @@
 <!-- src/views/PublicationCenterView/StatusFilters.svelte -->
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
-	import { FileStatus } from "./annotate";
+	import type { FileStatus } from "./annotate";
 
 	export let counts: Record<FileStatus, number>;
 	export let active: Set<FileStatus>;

--- a/src/views/SettingsView/ForestrySettings.svelte
+++ b/src/views/SettingsView/ForestrySettings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import DigitalGardenSettings from "../../models/settings";
+	import type DigitalGardenSettings from "../../models/settings";
 	import ForestryApi from "src/forestry/ForestryApi";
 	import type { IUserLimitsResponse } from "src/forestry/UserLimitsResponse";
 	import { Notice } from "obsidian";

--- a/src/views/SettingsView/RewriteSettings.svelte
+++ b/src/views/SettingsView/RewriteSettings.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import Publisher from "src/publisher/Publisher";
 
-	import { ChangeEventHandler } from "svelte/elements";
+	import type { ChangeEventHandler } from "svelte/elements";
 	import { getGardenPathForNote, getRewriteRules } from "../../utils/utils";
-	import DigitalGardenSettings from "../../models/settings";
-	import { Change, diffLines } from "diff";
+	import type DigitalGardenSettings from "../../models/settings";
+	import { diffLines } from "diff";
+	import type { Change } from "diff";
 	import LineDiff from "../../ui/LineDiff.svelte";
 
 	export let publisher: Publisher;


### PR DESCRIPTION
## Summary

**Fixes the broken 2.80.0 release** — the Publication Center dies with `Uncaught ReferenceError: Tutorial is not defined`, and the nav-order modal and Forestry/rewrite settings panes are equally broken.

## Root cause

The Svelte 5 migration (#805) brought svelte-preprocess v6, which requires `verbatimModuleSyntax` for TS. Our tsconfig sets it to `false`, so the TS transpile treated any import not referenced in the `<script>` body as type-only and stripped it. Component imports used **only in markup** have exactly that shape — so **every child Svelte component was dropped from the bundle** while the compiled markup still called them. esbuild doesn't error on this, and the build looked green (the only signal was a one-line warning above the success output).

Confirmed against the actual 2.80.0 release artifact: `Tutorial`, `Notices`, `StatusFilters`, `FileTree`, `DiffPane`, `PublishBar`, `Icon`, `LineDiff`, `SortableTree` and more are all referenced but never defined.

## Fix

- Enable `verbatimModuleSyntax` in the svelte-preprocess TS `compilerOptions` (scoped to the esbuild plugin; the project-wide tsconfig is unchanged)
- Mark pure type imports in `.svelte` files as `import type` (they now survive to esbuild, which correctly errors on unresolvable ones — that's the enforcement)

## Regression guard

`scripts/verifyBundle.mjs` now runs as part of `npm run build` (locally, CI, and the release workflow): it asserts every `.svelte` module imported from live code is present in the bundle, ignoring tree-shaken dead code. Verified in both directions: **fails against the broken 2.80.0 artifact (13 missing components), passes against the fixed build**.

## Validation

- `npm run build` — clean, bundle verification OK (16 components)
- `npm test` (93), `npm run typecheck`, `npm run lint`, `npm run check-formatting` — all clean
- Fixed build deployed to the Docs test vault for manual confirmation

After merge: release 2.80.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjEDfYQKACsRDKFrVuQ4VQ