### PR TITLE
fix: base cover thumbnails — preserve frontmatter image properties and publish wikilink covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,14 @@ LOCAL_GARDEN_PATH=../digitalgarden
 
 To preview plugin changes in the actual garden site:
 
-1. `npm run dev` in this repo (builds plugin, copies to test vault)
-2. Open test vault in Obsidian, run **"Export Garden to Local Folder"**
-3. `npm run dev` in the `digitalgarden/` folder (serves garden with hot reload)
+1. `npm run dev` in this repo (builds plugin, copies to test vault, generates the test vault settings from `.env`)
+2. `npm run dev:watch` in this repo (rebuilds and copies to the test vault on every save)
+3. Open the test vault in Obsidian
+4. `npm run dev` in the `digitalgarden/` folder (serves the garden on `http://localhost:8080` with hot reload)
+
+When `LOCAL_GARDEN_PATH` is set in `.env`, the generated test vault settings enable `localExportOnLoad`, so the plugin exports the garden to that folder automatically on every load. Combined with the `hot-reload` plugin in the test vault, every save gives you: rebuild → plugin reload in Obsidian → re-export → eleventy rebuild.
+
+To trigger an export manually (or from another vault), run the **"Export Garden to Local Folder"** command. The automatic export only runs when `ENABLE_DEVELOPER_TOOLS`, `localExportOnLoad`, and `localExportPath` are all set in the plugin's `data.json` — regular installs are unaffected.
 
 Note: this repository uses prettier and eslint to enforce code formatting and style. It is recommended to install these to your IDE for automatic formatting and error highlighting.
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -4,6 +4,8 @@ import builtins from 'builtin-modules'
 import esbuildSvelte from "esbuild-svelte";
 import sveltePreprocess from "svelte-preprocess";
 import dotenv from 'dotenv';
+import fs from 'fs/promises';
+import path from 'path';
 
 // Load environment variables from .env file
 dotenv.config();
@@ -16,8 +18,34 @@ if you want to view the source, please visit the github repository of this plugi
 `;
 
 const prod = (process.argv[2] === 'production');
+const watch = (process.argv[2] === 'watch');
 
-esbuild.build({
+const TEST_VAULT_PLUGIN_DIR = 'src/dg-testVault/.obsidian/plugins/obsidian-digital-garden';
+
+// After each successful rebuild, copy the output into the test vault so the
+// hot-reload plugin picks it up and reloads the plugin inside Obsidian.
+const copyToTestVault = {
+	name: 'copy-to-test-vault',
+	setup(build) {
+		build.onEnd(async (result) => {
+			if (result.errors.length > 0) return;
+
+			// The hot-reload plugin only watches plugins marked with this file
+			await fs.writeFile(path.join(TEST_VAULT_PLUGIN_DIR, '.hotreload'), '');
+
+			for (const file of ['main.js', 'styles.css', 'manifest.json']) {
+				try {
+					await fs.copyFile(file, path.join(TEST_VAULT_PLUGIN_DIR, file));
+				} catch (e) {
+					console.error(`Failed to copy ${file} to test vault:`, e.message);
+				}
+			}
+			console.log(`[${new Date().toLocaleTimeString()}] Copied build output to test vault`);
+		});
+	},
+};
+
+const buildOptions = {
 	banner: {
 		js: banner,
 	},
@@ -40,8 +68,17 @@ esbuild.build({
 		    typescript: { compilerOptions: { verbatimModuleSyntax: true } },
 		  }),
 		}),
+		...(watch ? [copyToTestVault] : []),
 	],
 	define: {
 		'process.env.FORESTRY_BASE_URL': JSON.stringify(process.env.FORESTRY_BASE_URL || "https://api.forestry.md/app"),
 	},
-}).catch(() => process.exit(1));
+};
+
+if (watch) {
+	const ctx = await esbuild.context(buildOptions);
+	await ctx.watch();
+	console.log('Watching for changes...');
+} else {
+	esbuild.build(buildOptions).catch(() => process.exit(1));
+}

--- a/main.ts
+++ b/main.ts
@@ -168,6 +168,7 @@ export default class DigitalGarden extends Plugin {
 		);
 
 		this.checkForTemplateUpdates();
+		this.registerDevAutoExport();
 	}
 
 	private async checkForTemplateUpdates() {
@@ -458,42 +459,60 @@ export default class DigitalGarden extends Plugin {
 				id: "export-garden-to-local-folder",
 				name: "Export Garden to Local Folder",
 				callback: async () => {
-					try {
-						new Notice("Exporting garden to local folder...");
-						const { vault, metadataCache } = this.app;
-
-						const publisher = new Publisher(
-							vault,
-							metadataCache,
-							this.settings,
-						);
-
-						const exporter = new LocalExporter(
-							vault,
-							publisher,
-							this.settings,
-						);
-
-						const result = await exporter.export();
-
-						if (result.failed > 0) {
-							new Notice(
-								`Exported ${result.notes} notes and ${result.images} images (${result.failed} failed). Check console for details.`,
-								8000,
-							);
-						} else {
-							new Notice(
-								`Exported ${result.notes} notes and ${result.images} images to ${this.settings.localExportPath}`,
-								8000,
-							);
-						}
-					} catch (e) {
-						// Validation errors already show Notices
-						Logger.error("Local export failed", e);
-					}
+					await this.runLocalExport();
 				},
 			});
 		}
+	}
+
+	private async runLocalExport() {
+		try {
+			new Notice("Exporting garden to local folder...");
+			const { vault, metadataCache } = this.app;
+
+			const publisher = new Publisher(
+				vault,
+				metadataCache,
+				this.settings,
+			);
+
+			const exporter = new LocalExporter(vault, publisher, this.settings);
+
+			const result = await exporter.export();
+
+			if (result.failed > 0) {
+				new Notice(
+					`Exported ${result.notes} notes and ${result.images} images (${result.failed} failed). Check console for details.`,
+					8000,
+				);
+			} else {
+				new Notice(
+					`Exported ${result.notes} notes and ${result.images} images to ${this.settings.localExportPath}`,
+					8000,
+				);
+			}
+		} catch (e) {
+			// Validation errors already show Notices
+			Logger.error("Local export failed", e);
+		}
+	}
+
+	private registerDevAutoExport() {
+		if (
+			!Platform.isDesktop ||
+			!this.settings.ENABLE_DEVELOPER_TOOLS ||
+			!this.settings.localExportOnLoad ||
+			!this.settings.localExportPath
+		) {
+			return;
+		}
+
+		this.app.workspace.onLayoutReady(() => {
+			// Let the metadata cache and plugins like Dataview settle first
+			window.setTimeout(() => {
+				this.runLocalExport();
+			}, 2000);
+		});
 	}
 
 	private getActiveFile(workspace: Workspace) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"postdev": "node scripts/generateGardenSettings.mjs",
+		"dev:watch": "node esbuild.config.mjs watch",
 		"dev1": "parcel main.ts",
 		"build": "node esbuild.config.mjs production && node scripts/verifyBundle.mjs",
 		"test": "jest",

--- a/scripts/generateGardenSettings.mjs
+++ b/scripts/generateGardenSettings.mjs
@@ -1,5 +1,6 @@
 import dotevnt from "dotenv";
 import fs from "fs";
+import path from "path";
 dotevnt.config();
 import copyfiles from "copyfiles";
 import Logger from "js-logger";
@@ -65,7 +66,12 @@ Path Rewriting/Subfolder:this-will-never-hit`,
 	ENABLE_DEVELOPER_TOOLS: true,
 	devPluginPath: `${process.cwd()}`,
 	logLevel: Logger.DEBUG,
-	localExportPath: process.env.LOCAL_GARDEN_PATH || "",
+	// Resolve to an absolute path: a relative path in data.json would resolve
+	// against Obsidian's cwd at runtime, not the plugin repo.
+	localExportPath: process.env.LOCAL_GARDEN_PATH
+		? path.resolve(process.env.LOCAL_GARDEN_PATH)
+		: "",
+	localExportOnLoad: Boolean(process.env.LOCAL_GARDEN_PATH),
 };
 
 const TEST_VAULT_PATH =

--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -121,6 +121,38 @@ export function createBaseCodeBlock(
 	);
 }
 
+const FRONTMATTER_IMAGE_EXTENSIONS = /\.(png|jpg|jpeg|gif|webp|svg)$/i;
+
+/**
+ * Extract a resolvable vault linkpath from a frontmatter property value
+ * that references an image. Handles plain paths ("attachments/cover.jpg")
+ * and wikilinks ("[[cover.jpg]]", "![[cover.jpg|300]]"). Returns null for
+ * external URLs and values that don't point at an image.
+ */
+export function getFrontmatterImageLinkpath(value: unknown): string | null {
+	if (typeof value !== "string") {
+		return null;
+	}
+
+	let linkpath = value.trim();
+
+	const wikilink = linkpath.match(/^!?\[\[([^\]]+)\]\]$/);
+
+	if (wikilink) {
+		linkpath = wikilink[1].split("|")[0].split("#")[0].trim();
+	}
+
+	if (linkpath.startsWith("http")) {
+		return null;
+	}
+
+	if (!FRONTMATTER_IMAGE_EXTENSIONS.test(linkpath)) {
+		return null;
+	}
+
+	return linkpath;
+}
+
 export class GardenPageCompiler implements ITextNodeProcessor {
 	private readonly vault: Vault;
 	private readonly settings: DigitalGardenSettings;
@@ -815,16 +847,13 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 
 		if (!frontmatter) return assets;
 
-		const imageExtensions = /\.(png|jpg|jpeg|gif|webp|svg)$/i;
-
 		const scanValue = async (value: unknown) => {
-			if (typeof value === "string" && imageExtensions.test(value)) {
-				// Skip external URLs
-				if (value.startsWith("http")) return;
+			const linkpath = getFrontmatterImageLinkpath(value);
 
+			if (linkpath) {
 				try {
 					const linkedFile = this.resolveLinkedFile(
-						value,
+						linkpath,
 						file.getPath(),
 					);
 
@@ -968,6 +997,15 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 		async (text: string): Promise<[string, Array<Asset>]> => {
 			const filePath = file.getPath();
 			const assets = [];
+
+			// Split off the frontmatter block and only convert the body:
+			// property values like cover: "[[image.png]]" must reach the
+			// site untouched so the bases engine can resolve them.
+			const frontmatterBlock = text.match(
+				/^\s*?---[\r\n][\s\S]*?[\r\n]---/,
+			);
+			const frontmatter = frontmatterBlock ? frontmatterBlock[0] : "";
+			text = text.slice(frontmatter.length);
 
 			let imageText = text;
 
@@ -1453,7 +1491,7 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 				}
 			}
 
-			return [imageText, assets];
+			return [frontmatter + imageText, assets];
 		};
 
 	generateTransclusionHeader(

--- a/src/dg-testVault/B Bases/B0 Cards with covers.md
+++ b/src/dg-testVault/B Bases/B0 Cards with covers.md
@@ -1,0 +1,41 @@
+---
+dg-publish: true
+---
+
+QA for base cards views with cover thumbnails. Every card below should show an image: the wikilink cover (travolta png), the plain path cover (travolta webp), and the external cover (hotlinked). See the notes in [[B1 Book with wikilink cover|Books]] for the three cover property shapes.
+
+## Embedded base, Obsidian syntax (`image: note.cover`)
+
+This is what Obsidian writes when you pick a card image in the UI:
+
+```base
+filters:
+  and:
+    - file.hasTag("bases-cover-test")
+views:
+  - type: cards
+    name: Covers obsidian syntax
+    image: note.cover
+    order:
+      - file.name
+      - year
+```
+
+## Embedded base, bare property name (`image: cover`)
+
+```base
+filters:
+  and:
+    - file.hasTag("bases-cover-test")
+views:
+  - type: cards
+    name: Covers bare syntax
+    image: cover
+    order:
+      - file.name
+      - year
+```
+
+## Transcluded standalone base
+
+![[B4 Covers.base]]

--- a/src/dg-testVault/B Bases/B4 Covers.base
+++ b/src/dg-testVault/B Bases/B4 Covers.base
@@ -1,0 +1,13 @@
+filters:
+  and:
+    - file.hasTag("bases-cover-test")
+properties:
+  note.year:
+    displayName: Year
+views:
+  - type: cards
+    name: Covers
+    order:
+      - file.name
+      - year
+    image: note.cover

--- a/src/dg-testVault/B Bases/Books/B1 Book with wikilink cover.md
+++ b/src/dg-testVault/B Bases/Books/B1 Book with wikilink cover.md
@@ -1,0 +1,9 @@
+---
+dg-publish: true
+tags:
+  - bases-cover-test
+cover: "[[A Assets/travolta.png]]"
+year: 2020
+---
+
+Book note whose `cover` property is a wikilink, the format Obsidian's image property picker produces. The cards views in [[B0 Cards with covers]] should show the travolta png as this note's thumbnail.

--- a/src/dg-testVault/B Bases/Books/B2 Book with plain path cover.md
+++ b/src/dg-testVault/B Bases/Books/B2 Book with plain path cover.md
@@ -1,0 +1,9 @@
+---
+dg-publish: true
+tags:
+  - bases-cover-test
+cover: A Assets/travolta.webp
+year: 2021
+---
+
+Book note whose `cover` property is a plain vault-relative path. The cards views in [[B0 Cards with covers]] should show the travolta webp as this note's thumbnail.

--- a/src/dg-testVault/B Bases/Books/B3 Book with external cover.md
+++ b/src/dg-testVault/B Bases/Books/B3 Book with external cover.md
@@ -1,0 +1,9 @@
+---
+dg-publish: true
+tags:
+  - bases-cover-test
+cover: https://docs.forestry.md/img/user/img/obsidianlogo.png
+year: 2022
+---
+
+Book note whose `cover` property is an external URL. The cards views in [[B0 Cards with covers]] should hotlink it unchanged (nothing is uploaded to the site repo for this one).

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -93,5 +93,7 @@ export default interface DigitalGardenSettings {
 	devPluginPath?: string;
 	logLevel?: ILogLevel;
 	localExportPath?: string;
+	/** Dev-only opt-in: run the local export automatically on plugin load. */
+	localExportOnLoad?: boolean;
 	contentBaseDir?: string;
 }

--- a/src/test/Compiler.test.ts
+++ b/src/test/Compiler.test.ts
@@ -10,6 +10,7 @@ import DigitalGardenSettings from "../models/settings";
 import {
 	createBaseCodeBlock,
 	GardenPageCompiler,
+	getFrontmatterImageLinkpath,
 	selectBaseView,
 } from "../compiler/GardenPageCompiler";
 import { PublishFile } from "../publishFile/PublishFile";
@@ -18,6 +19,7 @@ import { TRANSCLUDED_SVG_REGEX } from "../utils/regexes";
 jest.mock("obsidian", () => ({
 	parseYaml: jest.fn(),
 	stringifyYaml: jest.fn(),
+	getLinkpath: (linkpath: string) => linkpath,
 }));
 
 describe("Compiler", () => {
@@ -108,6 +110,96 @@ describe("Compiler", () => {
 			expect(result).toBe(
 				"Link with [[folder/test#My Header\\|custom display]] text",
 			);
+		});
+	});
+
+	describe("convertEmbeddedAssets", () => {
+		const getCompilerWithImageFile = () => {
+			return new GardenPageCompiler(
+				{} as Vault,
+				{ pathRewriteRules: "" } as DigitalGardenSettings,
+				{
+					getFirstLinkpathDest: jest.fn(() => ({
+						path: "A Assets/travolta.png",
+						extension: "png",
+					})),
+				} as unknown as MetadataCache,
+				jest.fn(),
+			);
+		};
+
+		const publishFile = {
+			getPath: () => "B Bases/Books/B1 Book.md",
+		} as PublishFile;
+
+		it("converts linked image wikilinks in the note body", async () => {
+			const compiler = getCompilerWithImageFile();
+
+			const [text] = await compiler.convertEmbeddedAssets(publishFile)(
+				"---\n" +
+					'{"dg-publish":true}\n' +
+					"---\n" +
+					"See [[A Assets/travolta.png]] for details.\n",
+			);
+
+			expect(text).toContain(
+				"[A Assets/travolta.png](/img/user/A%20Assets/travolta.png)",
+			);
+		});
+
+		it("leaves image wikilinks inside the frontmatter block untouched", async () => {
+			const compiler = getCompilerWithImageFile();
+
+			const frontmatter =
+				'{"dg-publish":true,"dg-note-properties":{"cover":"[[A Assets/travolta.png]]"}}';
+
+			const [text] = await compiler.convertEmbeddedAssets(publishFile)(
+				"---\n" +
+					frontmatter +
+					"\n---\n" +
+					"Body link [[A Assets/travolta.png]] still converts.\n",
+			);
+
+			expect(text).toContain(frontmatter);
+
+			expect(text).toContain(
+				"[A Assets/travolta.png](/img/user/A%20Assets/travolta.png)",
+			);
+		});
+	});
+
+	describe("getFrontmatterImageLinkpath", () => {
+		it("returns plain image paths as-is", () => {
+			expect(getFrontmatterImageLinkpath("attachments/cover.jpg")).toBe(
+				"attachments/cover.jpg",
+			);
+		});
+
+		it("unwraps wikilink image values", () => {
+			expect(getFrontmatterImageLinkpath("[[cover.jpg]]")).toBe(
+				"cover.jpg",
+			);
+		});
+
+		it("unwraps embed wikilinks with alias", () => {
+			expect(
+				getFrontmatterImageLinkpath("![[A Assets/cover.png|300]]"),
+			).toBe("A Assets/cover.png");
+		});
+
+		it("returns null for external URLs", () => {
+			expect(
+				getFrontmatterImageLinkpath("https://example.com/cover.jpg"),
+			).toBe(null);
+		});
+
+		it("returns null for non-image values", () => {
+			expect(getFrontmatterImageLinkpath("just a description")).toBe(
+				null,
+			);
+			expect(getFrontmatterImageLinkpath("[[Some note]]")).toBe(null);
+			expect(getFrontmatterImageLinkpath(42)).toBe(null);
+			expect(getFrontmatterImageLinkpath(null)).toBe(null);
 		});
 	});
 

--- a/src/test/snapshot/snapshot.md
+++ b/src/test/snapshot/snapshot.md
@@ -393,6 +393,104 @@ And for sanity, here's some block references outside of code blocks: foobar
 { #test-123}
 
 ==========
+B Bases/B0 Cards with covers.md
+==========
+---
+{"dg-publish":true,"permalink":"/b-bases/b0-cards-with-covers/","dg-note-properties":{}}
+---
+
+
+QA for base cards views with cover thumbnails. Every card below should show an image: the wikilink cover (travolta png), the plain path cover (travolta webp), and the external cover (hotlinked). See the notes in [[B Bases/Books/B1 Book with wikilink cover\|Books]] for the three cover property shapes.
+
+## Embedded base, Obsidian syntax (`image: note.cover`)
+
+This is what Obsidian writes when you pick a card image in the UI:
+
+```base
+filters:
+  and:
+    - file.hasTag("bases-cover-test")
+views:
+  - type: cards
+    name: Covers obsidian syntax
+    image: note.cover
+    order:
+      - file.name
+      - year
+```
+
+## Embedded base, bare property name (`image: cover`)
+
+```base
+filters:
+  and:
+    - file.hasTag("bases-cover-test")
+views:
+  - type: cards
+    name: Covers bare syntax
+    image: cover
+    order:
+      - file.name
+      - year
+```
+
+## Transcluded standalone base
+
+
+```base
+filters:
+  and:
+    - file.hasTag("bases-cover-test")
+properties:
+  note.year:
+    displayName: Year
+views:
+  - type: cards
+    name: Covers
+    order:
+      - file.name
+      - year
+    image: note.cover
+
+```
+
+
+==========
+B Bases/Books/B1 Book with wikilink cover.md
+==========
+---
+{"dg-publish":true,"permalink":"/b-bases/books/b1-book-with-wikilink-cover/","tags":["bases-cover-test"],"dg-note-properties":{"tags":["bases-cover-test"],"cover":"[[A Assets/travolta.png]]","year":2020}}
+---
+
+
+Book note whose `cover` property is a wikilink, the format Obsidian's image property picker produces. The cards views in [[B Bases/B0 Cards with covers\|B0 Cards with covers]] should show the travolta png as this note's thumbnail.
+
+/img/user/A Assets/travolta.png
+==========
+B Bases/Books/B2 Book with plain path cover.md
+==========
+---
+{"dg-publish":true,"permalink":"/b-bases/books/b2-book-with-plain-path-cover/","tags":["bases-cover-test"],"dg-note-properties":{"tags":["bases-cover-test"],"cover":"A Assets/travolta.webp","year":2021}}
+---
+
+
+Book note whose `cover` property is a plain vault-relative path. The cards views in [[B Bases/B0 Cards with covers\|B0 Cards with covers]] should show the travolta webp as this note's thumbnail.
+
+/img/user/A Assets/travolta.png
+,/img/user/A Assets/travolta.webp
+==========
+B Bases/Books/B3 Book with external cover.md
+==========
+---
+{"dg-publish":true,"permalink":"/b-bases/books/b3-book-with-external-cover/","tags":["bases-cover-test"],"dg-note-properties":{"tags":["bases-cover-test"],"cover":"https://docs.forestry.md/img/user/img/obsidianlogo.png","year":2022}}
+---
+
+
+Book note whose `cover` property is an external URL. The cards views in [[B Bases/B0 Cards with covers\|B0 Cards with covers]] should hotlink it unchanged (nothing is uploaded to the site repo for this one).
+
+/img/user/A Assets/travolta.png
+,/img/user/A Assets/travolta.webp
+==========
 E Embeds/E02 PNG published.md
 ==========
 ---
@@ -403,6 +501,7 @@ E Embeds/E02 PNG published.md
 
 ![travolta.png](/img/user/A%20Assets/travolta.png)
 /img/user/A Assets/travolta.png
+,/img/user/A Assets/travolta.webp
 ==========
 E Embeds/E04 PNG reuse.md
 ==========
@@ -414,6 +513,7 @@ This file uses the same image as in [[E Embeds/E03 PNG_not_published\|E03 PNG_no
 
 ![unused_image.png\|100](/img/user/A%20Assets/unused_image.png)
 /img/user/A Assets/travolta.png
+,/img/user/A Assets/travolta.webp
 ,/img/user/A Assets/unused_image.png
 ==========
 E Embeds/E05 WEBP published.md
@@ -425,8 +525,8 @@ E Embeds/E05 WEBP published.md
 
 ![travolta.webp](/img/user/A%20Assets/travolta.webp)
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 E Embeds/E07 Image with alt attributes.md
 ==========
@@ -443,15 +543,14 @@ This should render to an image with the alt text "left", like so:
 `[travolta.png\|left](/img/user/A%20Assets/travolta.png)`
 ![travolta.png\|left](/img/user/A%20Assets/travolta.png)
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 E Embeds/E08 Images in tables.md
 ==========
 ---
 {"dg-publish":true,"permalink":"/e-embeds/e08-images-in-tables/","dg-note-properties":{}}
 ---
-
 
 Images with resize syntax inside tables should render correctly.
 The pipe in the image size syntax is escaped as `\|` inside tables.
@@ -462,8 +561,8 @@ The pipe in the image size syntax is escaped as `\|` inside tables.
 | ![travolta.png](/img/user/A%20Assets/travolta.png) | Travolta full size |
 
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 E Embeds/Transclusions/T1 BaseFile.md
 ==========
@@ -547,8 +646,8 @@ Bonus pic:
 </div></div>
 
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 E Embeds/Transclusions/T2 Too deep to transclude.md
 ==========
@@ -560,8 +659,8 @@ This one isn't isn't transcluded anymore (too deep)
 
 ![travolta.png\|100](/img/user/A%20Assets/travolta.png)
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 E Embeds/Transclusions/T3 Transcluded block.md
 ==========
@@ -583,8 +682,8 @@ cheese
 
 
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 E Embeds/Transclusions/T4 Transcluded header.md
 ==========
@@ -609,8 +708,8 @@ This should be in this header block
 
 
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 E Embeds/Transclusions/T5 transclude custom filters.md
 ==========
@@ -636,8 +735,8 @@ this plugin has custom filter that turns 🌞 (snow emoji) into 🌞 (THE SUN). 
 </div></div>
 
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 E Embeds/Transclusions/T6 transclusion inside codeblock.md
 ==========
@@ -685,8 +784,8 @@ this plugin has custom filter that turns 🌞 (snow emoji) into 🌞 (THE SUN). 
 
 ```
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 E Embeds/Transclusions/T7 Transcluded base views.md
 ==========
@@ -766,8 +865,8 @@ views:
 
 
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 L Languages/Transclude Headers.md
 ==========
@@ -791,8 +890,8 @@ This should be visible when transcluding the header above
 
 
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 L Links/01 Link to header.md
 ==========
@@ -824,8 +923,8 @@ Same-file header link should be converted
 Same-file header link with custom display text
 [[L Links/01 Link to header#Some Header\|custom display]]
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 P Plugins/PD Dataview/PD1 Dataview.md
 ==========
@@ -848,8 +947,8 @@ I'm a list of all files in this folder:
 { .block-language-dataview}
 
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 P Plugins/PD Dataview/PD2 Inline queries.md
 ==========
@@ -864,8 +963,8 @@ PD2 Inline queries
 this note is about foo
 
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 P Plugins/PD Dataview/PD3 Inline JS queries.md
 ==========
@@ -875,12 +974,12 @@ P Plugins/PD Dataview/PD3 Inline JS queries.md
 
 
 3
-116
+124
 <p><span>A paragraph</span></p>
 
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 P Plugins/PD Dataview/PD4 DataviewJs queries.md
 ==========
@@ -894,8 +993,8 @@ P Plugins/PD Dataview/PD4 DataviewJs queries.md
 
 
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 P Plugins/PD Dataview/PD5.1 Dataview in transclusions.md
 ==========
@@ -909,8 +1008,8 @@ This should be a working link -> [kagi](https://kagi.com)
 
 See if those tran: [[P Plugins/PD Dataview/PD5.2 Dataview in transclusions\|PD5.2 Dataview in transclusions]]
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 P Plugins/PD Dataview/PD5.2 Dataview in transclusions.md
 ==========
@@ -936,8 +1035,8 @@ See if those tran: [[P Plugins/PD Dataview/PD5.2 Dataview in transclusions\|PD5.
 
 The transcluded, Dataview-containing transclusion above should have been processed as expected with the Dataview having been processed. e.g. the text and link should use the frontmatter from the original file per the Dataview queries in that file.
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 P Plugins/PE Excalidraw/PE1 Transcluded excalidraw.md
 ==========
@@ -948,8 +1047,8 @@ P Plugins/PE Excalidraw/PE1 Transcluded excalidraw.md
 
 <style> .container {font-family: sans-serif; text-align: center;} .button-wrapper button {z-index: 1;height: 40px; width: 100px; margin: 10px;padding: 5px;} .excalidraw .App-menu_top .buttonList { display: flex;} .excalidraw-wrapper { height: 800px; margin: 50px; position: relative;} :root[dir="ltr"] .excalidraw .layer-ui__wrapper .zen-mode-transition.App-menu_bottom--transition-left {transform: none;} </style><script src="https://cdn.jsdelivr.net/npm/react@17/umd/react.production.min.js"></script><script src="https://cdn.jsdelivr.net/npm/react-dom@17/umd/react-dom.production.min.js"></script><script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw@0/dist/excalidraw.production.min.js"></script><div id="Drawing_2023-09-23_2241.09.excalidraw.md1"></div><script>(function(){const InitialData={"type":"excalidraw","version":2,"source":"https://github.com/zsviczian/obsidian-excalidraw-plugin/releases/tag/1.9.19","elements":[{"id":"CZsgDfedEqsrXkSK9gQJH","type":"rectangle","x":-231.33984375,"y":-252.75,"width":222,"height":93.296875,"angle":0,"strokeColor":"#1e1e1e","backgroundColor":"transparent","fillStyle":"hachure","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"frameId":null,"roundness":{"type":3},"seed":834466567,"version":54,"versionNonce":1029562215,"isDeleted":false,"boundElements":[{"id":"ezIUrt6yrVW9zFYWBb6Fx","type":"arrow"}],"updated":1695498089101,"link":null,"locked":false},{"id":"SvNLuaih","type":"text","x":-179.35546875,"y":-209.0703125,"width":41.89994812011719,"height":25,"angle":0,"strokeColor":"#1e1e1e","backgroundColor":"transparent","fillStyle":"hachure","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"frameId":null,"roundness":null,"seed":1422140583,"version":5,"versionNonce":655470793,"isDeleted":false,"boundElements":null,"updated":1695498085088,"link":null,"locked":false,"text":"beep","rawText":"beep","fontSize":20,"fontFamily":1,"textAlign":"left","verticalAlign":"top","baseline":18,"containerId":null,"originalText":"beep","lineHeight":1.25},{"id":"ezIUrt6yrVW9zFYWBb6Fx","type":"arrow","x":-8.67578125,"y":-157.16796875,"width":105.06640625,"height":109.1796875,"angle":0,"strokeColor":"#1e1e1e","backgroundColor":"transparent","fillStyle":"hachure","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"frameId":null,"roundness":{"type":2},"seed":1011929737,"version":32,"versionNonce":1434943559,"isDeleted":false,"boundElements":null,"updated":1695498089101,"link":null,"locked":false,"points":[[0,0],[105.06640625,109.1796875]],"lastCommittedPoint":null,"startBinding":{"elementId":"CZsgDfedEqsrXkSK9gQJH","focus":-0.4142254509017335,"gap":2.28515625},"endBinding":null,"startArrowhead":null,"endArrowhead":"arrow"},{"id":"DCQM7O8k","type":"text","x":112.515625,"y":-27.84375,"width":42.17994689941406,"height":25,"angle":0,"strokeColor":"#1e1e1e","backgroundColor":"transparent","fillStyle":"hachure","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"frameId":null,"roundness":null,"seed":358308487,"version":5,"versionNonce":1560033513,"isDeleted":false,"boundElements":null,"updated":1695498093145,"link":null,"locked":false,"text":"boop","rawText":"boop","fontSize":20,"fontFamily":1,"textAlign":"left","verticalAlign":"top","baseline":18,"containerId":null,"originalText":"boop","lineHeight":1.25},{"id":"rN0xD5d1otB0Txp8mrVKE","type":"rectangle","x":94.73046875,"y":-44.63671875,"width":76.48046875,"height":59.0703125,"angle":0,"strokeColor":"#1e1e1e","backgroundColor":"transparent","fillStyle":"hachure","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"frameId":null,"roundness":{"type":3},"seed":1024447145,"version":54,"versionNonce":1399780105,"isDeleted":false,"boundElements":null,"updated":1695498097327,"link":null,"locked":false},{"id":"EAi6LVWi5tLJIMLTDPXa7","type":"line","x":93.21875,"y":24.30078125,"width":80.23046875,"height":83.078125,"angle":0,"strokeColor":"#1e1e1e","backgroundColor":"transparent","fillStyle":"hachure","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"frameId":null,"roundness":{"type":2},"seed":795411751,"version":27,"versionNonce":309139625,"isDeleted":false,"boundElements":null,"updated":1695498103612,"link":null,"locked":false,"points":[[0,0],[-80.23046875,83.078125]],"lastCommittedPoint":null,"startBinding":null,"endBinding":null,"startArrowhead":null,"endArrowhead":null},{"id":"LIzHXsQpdg5HRqdFJywOn","type":"rectangle","x":-90.056640625,"y":115.9765625,"width":103,"height":59,"angle":0,"strokeColor":"#1e1e1e","backgroundColor":"transparent","fillStyle":"hachure","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"frameId":null,"roundness":{"type":3},"seed":611720073,"version":64,"versionNonce":2050110535,"isDeleted":false,"boundElements":[{"type":"text","id":"ASLeSCTL"}],"updated":1695498114978,"link":null,"locked":false},{"id":"ASLeSCTL","type":"text","x":-64.65660858154297,"y":132.9765625,"width":52.19993591308594,"height":25,"angle":0,"strokeColor":"#1e1e1e","backgroundColor":"transparent","fillStyle":"hachure","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"frameId":null,"roundness":null,"seed":1398305225,"version":6,"versionNonce":1100335623,"isDeleted":false,"boundElements":null,"updated":1695498114039,"link":null,"locked":false,"text":"bebop","rawText":"bebop","fontSize":20,"fontFamily":1,"textAlign":"center","verticalAlign":"middle","baseline":18,"containerId":"LIzHXsQpdg5HRqdFJywOn","originalText":"bebop","lineHeight":1.25}],"appState":{"theme":"light","viewBackgroundColor":"#ffffff","currentItemStrokeColor":"#1e1e1e","currentItemBackgroundColor":"transparent","currentItemFillStyle":"hachure","currentItemStrokeWidth":1,"currentItemStrokeStyle":"solid","currentItemRoughness":1,"currentItemOpacity":100,"currentItemFontFamily":1,"currentItemFontSize":20,"currentItemTextAlign":"left","currentItemStartArrowhead":null,"currentItemEndArrowhead":"arrow","scrollX":339,"scrollY":360.9765625,"zoom":{"value":1},"currentItemRoundness":"round","gridSize":null,"gridColor":{"Bold":"#C9C9C9FF","Regular":"#EDEDEDFF"},"currentStrokeOptions":null,"previousGridSize":null,"frameRendering":{"enabled":true,"clip":true,"name":true,"outline":true}},"files":{}};InitialData.scrollToContent=true;App=()=>{const e=React.useRef(null),t=React.useRef(null),[n,i]=React.useState({width:void 0,height:void 0});return React.useEffect(()=>{i({width:t.current.getBoundingClientRect().width,height:t.current.getBoundingClientRect().height});const e=()=>{i({width:t.current.getBoundingClientRect().width,height:t.current.getBoundingClientRect().height})};return window.addEventListener("resize",e),()=>window.removeEventListener("resize",e)},[t]),React.createElement(React.Fragment,null,React.createElement("div",{className:"excalidraw-wrapper",ref:t},React.createElement(ExcalidrawLib.Excalidraw,{ref:e,width:n.width,height:n.height,initialData:InitialData,viewModeEnabled:!0,zenModeEnabled:!0,gridModeEnabled:!1})))},excalidrawWrapper=document.getElementById("Drawing_2023-09-23_2241.09.excalidraw.md1");ReactDOM.render(React.createElement(App),excalidrawWrapper);})();</script>
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 P Plugins/PE Excalidraw/PE2 excalidraw with image.md
 ==========
@@ -964,8 +1063,8 @@ P Plugins/PE Excalidraw/PE2 excalidraw with image.md
 
 
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 Path Rewriting/004 Folder set to root.md
 ==========
@@ -982,8 +1081,8 @@ This means this file should be in the root directory :)
 This subfolder also contains path rewrite testing! 
 
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 Path Rewriting/Subfolder/How deep do the rewrite rules go.md
 ==========
@@ -1003,8 +1102,8 @@ Will this file be in folder `subfolder-rewritten` or in `Subfolder`?
 
 It should be in Subfolder as "matching exits on first hit"
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========
 Path Rewriting/Subfolder2/More specific path rewriting.md
 ==========
@@ -1019,6 +1118,6 @@ Path Rewriting/Subfolder2:fun-folder
 Path Rewriting:
 ```
 /img/user/A Assets/travolta.png
-,/img/user/A Assets/unused_image.png
 ,/img/user/A Assets/travolta.webp
+,/img/user/A Assets/unused_image.png
 ==========


### PR DESCRIPTION
## Summary

Cover thumbnails in published bases were broken for the property shapes Obsidian itself produces (reported in the Discord community). Two plugin-side bugs fixed:

- **Frontmatter mangling**: `convertEmbeddedAssets` ran over the whole compiled text including the JSON frontmatter block, rewriting values like `cover: "[[image.png]]"` into markdown links the site's bases engine couldn't resolve. The frontmatter block is now split off before any asset conversion and reattached untouched — byte-identical output for all pre-existing snapshot content.
- **Missing asset upload**: frontmatter image values in wikilink form were never published, because the extension check was anchored to end-of-string and `"[[cover.jpg]]"` ends in `]]`. The new `getFrontmatterImageLinkpath` helper unwraps wikilink/embed syntax (`[[x]]`, `![[x|300]]`) before the extension test and vault resolution, so the image is uploaded to `/img/user/…` alongside the note.

## Test plan

- New jest tests: `convertEmbeddedAssets` converts body image wikilinks but leaves frontmatter untouched (this test caught a first-attempt fix that skipped matches by index but still replaced the frontmatter occurrence via replace-by-value); `getFrontmatterImageLinkpath` covers plain paths, wikilinks, embeds with alias, external URLs, and non-image values.
- New `B Bases` QA folder in the test vault: cards views (embedded `image: note.cover` Obsidian syntax, bare `image: cover`, and a transcluded standalone base) over book notes with wikilink, plain-path, and external covers. Verified end-to-end against the 11ty build: all nine thumbnails render.
- Garden snapshot regenerated; diff reviewed — only the new notes, cumulative asset-list reordering, and the Dataview page-count change.
- Full suite: 100/100 jest, tsc clean, eslint clean.

Companion PR in the `digitalgarden` template resolves `note.`-prefixed image fields and wikilink/markdown-link cover values at render time (also fixes gardens already published with mangled frontmatter).
