### PR TITLE
fix: track frontmatter cover images so batch publish stops deleting them

### DIFF
--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -834,6 +834,36 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 	};
 
 	/**
+	 * Collect image linkpaths referenced by frontmatter properties
+	 * (plain paths, wikilinks, or arrays of either).
+	 */
+	private getFrontmatterImageLinkpaths(file: PublishFile): string[] {
+		const linkpaths: string[] = [];
+
+		const frontmatter = this.metadataCache.getFileCache(file.file)
+			?.frontmatter;
+
+		if (!frontmatter) return linkpaths;
+
+		const scanValue = (value: unknown) => {
+			const linkpath = getFrontmatterImageLinkpath(value);
+
+			if (linkpath) {
+				linkpaths.push(linkpath);
+			} else if (Array.isArray(value)) {
+				value.forEach(scanValue);
+			}
+		};
+
+		for (const [key, value] of Object.entries(frontmatter)) {
+			if (key === "position") continue;
+			scanValue(value);
+		}
+
+		return linkpaths;
+	}
+
+	/**
 	 * Scan frontmatter properties for values that look like image paths
 	 * and include them as assets so they get published alongside the note.
 	 */
@@ -842,44 +872,26 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 	): Promise<Array<Asset>> {
 		const assets: Array<Asset> = [];
 
-		const frontmatter = this.metadataCache.getFileCache(file.file)
-			?.frontmatter;
+		for (const linkpath of this.getFrontmatterImageLinkpaths(file)) {
+			try {
+				const linkedFile = this.resolveLinkedFile(
+					linkpath,
+					file.getPath(),
+				);
 
-		if (!frontmatter) return assets;
+				if (!linkedFile) continue;
 
-		const scanValue = async (value: unknown) => {
-			const linkpath = getFrontmatterImageLinkpath(value);
+				const image = await this.vault.readBinary(linkedFile);
+				const imageBase64 = arrayBufferToBase64(image);
 
-			if (linkpath) {
-				try {
-					const linkedFile = this.resolveLinkedFile(
-						linkpath,
-						file.getPath(),
-					);
-
-					if (!linkedFile) return;
-
-					const image = await this.vault.readBinary(linkedFile);
-					const imageBase64 = arrayBufferToBase64(image);
-
-					assets.push({
-						path: `/img/user/${linkedFile.path}`,
-						content: imageBase64,
-						localHash: generateBlobHashFromBase64(imageBase64),
-					});
-				} catch {
-					// Skip unresolvable paths
-				}
-			} else if (Array.isArray(value)) {
-				for (const item of value) {
-					await scanValue(item);
-				}
+				assets.push({
+					path: `/img/user/${linkedFile.path}`,
+					content: imageBase64,
+					localHash: generateBlobHashFromBase64(imageBase64),
+				});
+			} catch {
+				// Skip unresolvable paths
 			}
-		};
-
-		for (const [key, value] of Object.entries(frontmatter)) {
-			if (key === "position") continue;
-			await scanValue(value);
 		}
 
 		return assets;
@@ -986,6 +998,17 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 				assets.push(linkedFile.path);
 			} catch {
 				continue;
+			}
+		}
+
+		// Frontmatter image properties (e.g. cover) are published by
+		// extractFrontmatterAssets, so they must be tracked here too or
+		// they get flagged as orphaned and deleted on batch publishes.
+		for (const linkpath of this.getFrontmatterImageLinkpaths(file)) {
+			const linkedFile = this.resolveLinkedFile(linkpath, file.getPath());
+
+			if (linkedFile) {
+				assets.push(linkedFile.path);
 			}
 		}
 

--- a/src/test/Compiler.test.ts
+++ b/src/test/Compiler.test.ts
@@ -168,6 +168,104 @@ describe("Compiler", () => {
 		});
 	});
 
+	describe("extractImageLinks", () => {
+		const getCompilerWithFrontmatter = (
+			frontmatter: Record<string, unknown>,
+		) => {
+			return new GardenPageCompiler(
+				{} as Vault,
+				{ pathRewriteRules: "" } as DigitalGardenSettings,
+				{
+					getFirstLinkpathDest: jest.fn((linkpath: string) => ({
+						path: linkpath,
+						extension: linkpath.split(".").pop(),
+					})),
+					getFileCache: jest.fn(() => ({ frontmatter })),
+				} as unknown as MetadataCache,
+				jest.fn(),
+			);
+		};
+
+		const getPublishFile = (rawText: string) =>
+			({
+				file: {} as TFile,
+				getPath: () => "B Bases/Books/B2 Book.md",
+				cachedRead: async () => rawText,
+			}) as unknown as PublishFile;
+
+		it("includes plain-path frontmatter cover images", async () => {
+			const compiler = getCompilerWithFrontmatter({
+				"dg-publish": true,
+				cover: "A Assets/travolta.webp",
+			});
+
+			const assets = await compiler.extractImageLinks(
+				getPublishFile(
+					"---\ndg-publish: true\ncover: A Assets/travolta.webp\n---\nBody text.\n",
+				),
+			);
+
+			expect(assets).toContain("A Assets/travolta.webp");
+		});
+
+		it("includes wikilink frontmatter cover images", async () => {
+			const compiler = getCompilerWithFrontmatter({
+				"dg-publish": true,
+				cover: "[[A Assets/travolta.png]]",
+			});
+
+			const assets = await compiler.extractImageLinks(
+				getPublishFile(
+					'---\ndg-publish: true\ncover: "[[A Assets/travolta.png]]"\n---\nBody text.\n',
+				),
+			);
+
+			expect(assets).toContain("A Assets/travolta.png");
+		});
+
+		it("includes covers listed in array frontmatter properties", async () => {
+			const compiler = getCompilerWithFrontmatter({
+				"dg-publish": true,
+				covers: ["A Assets/one.png", "[[A Assets/two.jpg]]"],
+			});
+
+			const assets = await compiler.extractImageLinks(
+				getPublishFile("---\ndg-publish: true\n---\nBody text.\n"),
+			);
+
+			expect(assets).toContain("A Assets/one.png");
+			expect(assets).toContain("A Assets/two.jpg");
+		});
+
+		it("ignores external URL and non-image frontmatter values", async () => {
+			const compiler = getCompilerWithFrontmatter({
+				"dg-publish": true,
+				cover: "https://example.com/cover.jpg",
+				description: "just text",
+			});
+
+			const assets = await compiler.extractImageLinks(
+				getPublishFile("---\ndg-publish: true\n---\nBody text.\n"),
+			);
+
+			expect(assets).toEqual([]);
+		});
+
+		it("still extracts body image embeds", async () => {
+			const compiler = getCompilerWithFrontmatter({
+				"dg-publish": true,
+			});
+
+			const assets = await compiler.extractImageLinks(
+				getPublishFile(
+					"---\ndg-publish: true\n---\n![[A Assets/travolta.png]]\n",
+				),
+			);
+
+			expect(assets).toContain("A Assets/travolta.png");
+		});
+	});
+
 	describe("getFrontmatterImageLinkpath", () => {
 		it("returns plain image paths as-is", () => {
 			expect(getFrontmatterImageLinkpath("attachments/cover.jpg")).toBe(


### PR DESCRIPTION
## Problem

Follow-up to #808. Frontmatter cover images are uploaded correctly on every publish route, but batch publishing deleted them again immediately:

- `extractImageLinks` (which feeds `getFilesMarkedForPublishing().images`) only scanned body embeds, so frontmatter-only covers never appeared in the tracked image list.
- `PublishStatusManager` classifies any remote image not in that list as orphaned (`deletedImagePaths`).
- The **Publish All Notes Marked for Publish** command auto-deletes those right after `publishBatch`, and the **Publication Center** pre-selects them for deletion by default.

Net effect: the note's cover link renders fine, but the image 404s because it was uploaded and then removed as a false orphan in the same run.

## Fix

`extractImageLinks` now also scans frontmatter properties for image references (plain paths, wikilinks, arrays), using a new shared `getFrontmatterImageLinkpaths` helper that `extractFrontmatterAssets` reuses too. Covers are now present in `marked.images`, so they are no longer flagged as orphaned anywhere.

## Tests

TDD: new `extractImageLinks` tests written first (plain-path cover failed red, then green):
- plain-path frontmatter cover included
- wikilink frontmatter cover included
- array frontmatter properties included
- external URLs / non-image values ignored
- body embeds still extracted

Full suite: 105/105 passing. Lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ci2iQh4XaJZuxRQKyxW2y