### PR TITLE
feat: redact unpublished transclusions instead of leaking them

### DIFF
--- a/src/compiler/CanvasCompiler.ts
+++ b/src/compiler/CanvasCompiler.ts
@@ -12,6 +12,7 @@ import {
 } from "../utils/utils";
 import { FrontmatterCompiler } from "./FrontmatterCompiler";
 import { hasPublishFlag } from "../publishFile/Validator";
+import { Base64 } from "js-base64";
 // Interface for text node processing - allows GardenPageCompiler to provide its compile steps
 export interface ITextNodeProcessor {
 	processTextNodeContent: (
@@ -283,7 +284,7 @@ export class CanvasCompiler {
 		}
 
 		// Store processed markdown in base64 data attribute for 11ty to render at build time
-		const base64Markdown = Buffer.from(processedText).toString("base64");
+		const base64Markdown = Base64.encode(processedText);
 
 		// Apply text alignment from styleAttributes
 		const textAlign = node.styleAttributes?.textAlign;

--- a/src/compiler/CanvasCompiler.ts
+++ b/src/compiler/CanvasCompiler.ts
@@ -11,7 +11,7 @@ import {
 	sanitizePermalink,
 } from "../utils/utils";
 import { FrontmatterCompiler } from "./FrontmatterCompiler";
-
+import { hasPublishFlag } from "../publishFile/Validator";
 // Interface for text node processing - allows GardenPageCompiler to provide its compile steps
 export interface ITextNodeProcessor {
 	processTextNodeContent: (
@@ -423,6 +423,43 @@ export class CanvasCompiler {
 
 		// For markdown files, use an iframe
 		const label = node.file.replace(/\.md$/, "").split("/").pop() || "";
+
+		const linkedFile = this.metadataCache.getFirstLinkpathDest(
+			getLinkpath(node.file),
+			file.getPath(),
+		);
+		let isPublished = false;
+
+		if (linkedFile) {
+			const frontMatter = this.metadataCache.getCache(linkedFile.path)
+				?.frontmatter;
+			isPublished = hasPublishFlag(frontMatter);
+		}
+
+		if (!isPublished) {
+			const lockIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity: 0.6;"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>`;
+
+			const redactedHtml = `
+<div style="width: 100%; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-muted); background: var(--background-secondary); border-radius: 8px; border: 2px dashed var(--background-modifier-border); box-sizing: border-box; padding: 12px; text-align: center; gap: 8px; transition: all 0.2s ease;">
+	${lockIcon}
+	<div style="font-size: 14px; font-weight: 500; opacity: 0.9; letter-spacing: 0.3px;">Protected block</div>
+	<code style="font-size: 11px; max-width: 90%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding: 3px 8px; background: var(--background-primary); border: 1px solid var(--background-modifier-border-hover); border-radius: 6px; box-shadow: 0 1px 2px rgba(0,0,0,0.05);">${this.escapeHtml(
+		label,
+	)}</code>
+</div>`;
+
+			return `<div class="canvas-node canvas-node-file ${colorClass}" data-node-id="${
+				node.id
+			}" data-file-path="${this.escapeHtml(
+				node.file,
+			)}" style="${baseStyle}">
+	<div class="canvas-node-container" style="border: none !important; background: transparent !important; box-shadow: none !important; padding: 0 !important; overflow: hidden;">
+		<div class="canvas-node-content" style="height: 100%; width: 100%; padding: 0 !important; overflow: hidden;">
+			${redactedHtml}
+		</div>
+	</div>
+</div>`;
+		}
 
 		return `<div class="canvas-node canvas-node-file ${colorClass}" data-node-id="${
 			node.id

--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -685,7 +685,10 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 								(f) => f.getPath() == linkedFile.path,
 							);
 
-						if (publishedFilesContainsLinkedFile) {
+						if (!publishedFilesContainsLinkedFile) {
+							const lockIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink: 0;"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>`;
+							fileText = `\n<div style="padding: 12px 16px; margin: 1rem 0; border-radius: 8px; border: 1px dashed var(--text-muted); background: var(--background-secondary); display: flex; align-items: center; gap: 10px; color: var(--text-muted); font-size: 0.9em;">${lockIcon}<span>Protected block: <code>${transclusionFileName}</code></span></div>\n\n`;
+						} else {
 							const permalink =
 								metadata?.frontmatter &&
 								metadata.frontmatter["dg-permalink"];
@@ -700,17 +703,17 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 										this.settings.slugifyEnabled,
 								  )}`;
 							embedded_link = `<a class="markdown-embed-link" href="${gardenPath}${sectionID}" aria-label="Open link"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg></a>`;
-						}
 
-						fileText =
-							`\n<div class="transclusion internal-embed is-loaded">${embedded_link}<div class="markdown-embed">\n\n${headerSection}\n\n` +
-							fileText +
-							"\n\n</div></div>\n";
+							fileText =
+								`\n<div class="transclusion internal-embed is-loaded">${embedded_link}<div class="markdown-embed">\n\n${headerSection}\n\n` +
+								fileText +
+								"\n\n</div></div>\n";
 
-						if (fileText.match(transcludedRegex)) {
-							fileText = await this.createTranscludedText(
-								currentDepth + 1,
-							)(publishLinkedFile)(fileText);
+							if (fileText.match(transcludedRegex)) {
+								fileText = await this.createTranscludedText(
+									currentDepth + 1,
+								)(publishLinkedFile)(fileText);
+							}
 						}
 
 						// compile dataview in transcluded text


### PR DESCRIPTION
### Problem
Currently, the plugin resolves all embeds (`![[file]]`) during compilation. If a user maintains a workflow where they atomic-embed private notes (e.g., notes that do *not* have `dg-publish: true`) into a public note to outline structure, the plugin physically bakes the private, sensitive content into the generated HTML. This can lead to accidental data leaks of private vault information.

### Solution
This PR introduces a strict security boundary in `GardenPageCompiler.ts`. 
If a transcluded file is *not* found in the `publishedFiles` list, the compiler will intercept it and replace the embed with a "Protected block" UI instead of leaking its contents.

### Implementation Details
- **Highly Optimized:** It uses a single inline HTML snippet with flexbox to perfectly scale on mobile devices.
- **Zero-Config Styling:** It introduces zero external CSS classes. Instead, it dynamically inherits the native Obsidian CSS variables (`var(--text-muted)` and `var(--background-secondary)`) so it automatically matches whatever Digital Garden theme the user has installed.
- **Minimal footprint:** It just adds an `svg` lock icon and the referenced filename, providing a great user experience over a dead 404 link while maintaining absolute privacy.
<img width="524" height="492" alt="image" src="https://github.com/user-attachments/assets/e2746a2f-e51e-4dd2-a2e2-722401e6eb15" />

