### PR TITLE
fix: heal missing frontmatter cover images and resolve them to full vault paths

### DIFF
--- a/src/compiler/FrontmatterCompiler.test.ts
+++ b/src/compiler/FrontmatterCompiler.test.ts
@@ -82,3 +82,80 @@ describe("FrontmatterCompiler hide flags", () => {
 		expect(parsePublished(result).hideInGraph).toBe(true);
 	});
 });
+
+describe("FrontmatterCompiler image property resolution", () => {
+	// Vault layout the fake metadataCache resolves against
+	const vaultImages: Record<string, string> = {
+		"cover.jpg": "06 Assets/covers/cover.jpg",
+		"06 Assets/covers/cover.jpg": "06 Assets/covers/cover.jpg",
+		"attachments/cover.jpg": "06 Assets/attachments/cover.jpg",
+	};
+
+	const fakeFileWithVault = (path = "notes/test.md") =>
+		({
+			getPath: () => path,
+			meta: {
+				getUpdatedAt: () => undefined,
+				getCreatedAt: () => undefined,
+			},
+			metadataCache: {
+				getFirstLinkpathDest: (linkpath: string) =>
+					vaultImages[linkpath]
+						? { path: vaultImages[linkpath] }
+						: null,
+			},
+		}) as unknown as PublishFile;
+
+	const getUserProps = (frontmatter: Record<string, unknown>) => {
+		const compiler = getCompiler();
+
+		const result = compiler.compile(
+			fakeFileWithVault(),
+			frontmatter as unknown as FrontMatterCache,
+		);
+
+		return parsePublished(result)["dg-note-properties"] as Record<
+			string,
+			unknown
+		>;
+	};
+
+	it("resolves shortest-path wikilink image values to full vault paths", () => {
+		const props = getUserProps({ cover: "[[cover.jpg]]" });
+		expect(props.cover).toBe("[[06 Assets/covers/cover.jpg]]");
+	});
+
+	it("keeps already-full wikilink image paths unchanged", () => {
+		const props = getUserProps({
+			cover: "[[06 Assets/covers/cover.jpg]]",
+		});
+		expect(props.cover).toBe("[[06 Assets/covers/cover.jpg]]");
+	});
+
+	it("preserves embed marker and alias when resolving", () => {
+		const props = getUserProps({ cover: "![[cover.jpg|300]]" });
+		expect(props.cover).toBe("![[06 Assets/covers/cover.jpg|300]]");
+	});
+
+	it("resolves plain path image values", () => {
+		const props = getUserProps({ cover: "attachments/cover.jpg" });
+		expect(props.cover).toBe("06 Assets/attachments/cover.jpg");
+	});
+
+	it("leaves unresolvable image wikilinks untouched", () => {
+		const props = getUserProps({ cover: "[[missing.jpg]]" });
+		expect(props.cover).toBe("[[missing.jpg]]");
+	});
+
+	it("leaves note wikilinks untouched", () => {
+		const props = getUserProps({ author: "[[David Berman]]" });
+		expect(props.author).toBe("[[David Berman]]");
+	});
+
+	it("leaves external image URLs untouched", () => {
+		const props = getUserProps({
+			cover: "https://example.com/cover.jpg",
+		});
+		expect(props.cover).toBe("https://example.com/cover.jpg");
+	});
+});

--- a/src/compiler/FrontmatterCompiler.ts
+++ b/src/compiler/FrontmatterCompiler.ts
@@ -9,6 +9,7 @@ import {
 import DigitalGardenSettings from "../models/settings";
 import { PathRewriteRules } from "../repositoryConnection/DigitalGardenSiteManager";
 import { PublishFile } from "../publishFile/PublishFile";
+import { resolveFrontmatterImageValue } from "./frontmatterImageLinks";
 
 export type TFrontmatter = Record<string, unknown> & {
 	"dg-path"?: string;
@@ -87,7 +88,10 @@ export class FrontmatterCompiler {
 		// under "dg-note-properties" to avoid clashing with 11ty reserved
 		// keys (date, layout, pagination, etc.) that would crash the build.
 		// The bases engine reads from this nested object when evaluating queries.
-		const userProperties = this.extractUserProperties(fileFrontMatter);
+		const userProperties = this.resolveImageProperties(
+			this.extractUserProperties(fileFrontMatter),
+			file,
+		);
 
 		const fullFrontMatter = publishedFrontMatter?.dgPassFrontmatter
 			? {
@@ -306,6 +310,31 @@ export class FrontmatterCompiler {
 	 * Obsidian internal fields and dg-* plugin fields that are already
 	 * handled by the compilation pipeline.
 	 */
+	/**
+	 * Rewrite image-referencing property values (e.g. cover: "[[img.jpg]]")
+	 * to their full vault path via the vault's own link resolution, so the
+	 * published value matches where the asset is actually uploaded.
+	 */
+	private resolveImageProperties(
+		userProps: Record<string, unknown>,
+		file: PublishFile,
+	): Record<string, unknown> {
+		const resolved: Record<string, unknown> = {};
+
+		for (const [key, value] of Object.entries(userProps)) {
+			resolved[key] = resolveFrontmatterImageValue(
+				value,
+				(linkpath) =>
+					file.metadataCache.getFirstLinkpathDest(
+						linkpath,
+						file.getPath(),
+					)?.path ?? null,
+			);
+		}
+
+		return resolved;
+	}
+
 	private extractUserProperties(
 		frontmatter: Record<string, unknown>,
 	): Record<string, unknown> {

--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -42,6 +42,9 @@ const PDF_IFRAME_HEIGHT = "900px";
 const PDF_IFRAME_STYLE = "border:1px solid #ccc;";
 import { PublishFile } from "../publishFile/PublishFile";
 import { replaceBlockIDs } from "./replaceBlockIDs";
+import { getFrontmatterImageLinkpath } from "./frontmatterImageLinks";
+
+export { getFrontmatterImageLinkpath };
 
 export interface Asset {
 	path: string;
@@ -119,38 +122,6 @@ export function createBaseCodeBlock(
 		selectBaseView(baseFileText, selectedViewName?.trim(), baseFileName) +
 		"\n```\n"
 	);
-}
-
-const FRONTMATTER_IMAGE_EXTENSIONS = /\.(png|jpg|jpeg|gif|webp|svg)$/i;
-
-/**
- * Extract a resolvable vault linkpath from a frontmatter property value
- * that references an image. Handles plain paths ("attachments/cover.jpg")
- * and wikilinks ("[[cover.jpg]]", "![[cover.jpg|300]]"). Returns null for
- * external URLs and values that don't point at an image.
- */
-export function getFrontmatterImageLinkpath(value: unknown): string | null {
-	if (typeof value !== "string") {
-		return null;
-	}
-
-	let linkpath = value.trim();
-
-	const wikilink = linkpath.match(/^!?\[\[([^\]]+)\]\]$/);
-
-	if (wikilink) {
-		linkpath = wikilink[1].split("|")[0].split("#")[0].trim();
-	}
-
-	if (linkpath.startsWith("http")) {
-		return null;
-	}
-
-	if (!FRONTMATTER_IMAGE_EXTENSIONS.test(linkpath)) {
-		return null;
-	}
-
-	return linkpath;
 }
 
 export class GardenPageCompiler implements ITextNodeProcessor {

--- a/src/compiler/frontmatterImageLinks.ts
+++ b/src/compiler/frontmatterImageLinks.ts
@@ -1,0 +1,70 @@
+const FRONTMATTER_IMAGE_EXTENSIONS = /\.(png|jpg|jpeg|gif|webp|svg)$/i;
+
+/**
+ * Extract a resolvable vault linkpath from a frontmatter property value
+ * that references an image. Handles plain paths ("attachments/cover.jpg")
+ * and wikilinks ("[[cover.jpg]]", "![[cover.jpg|300]]"). Returns null for
+ * external URLs and values that don't point at an image.
+ */
+export function getFrontmatterImageLinkpath(value: unknown): string | null {
+	if (typeof value !== "string") {
+		return null;
+	}
+
+	let linkpath = value.trim();
+
+	const wikilink = linkpath.match(/^!?\[\[([^\]]+)\]\]$/);
+
+	if (wikilink) {
+		linkpath = wikilink[1].split("|")[0].split("#")[0].trim();
+	}
+
+	if (linkpath.startsWith("http")) {
+		return null;
+	}
+
+	if (!FRONTMATTER_IMAGE_EXTENSIONS.test(linkpath)) {
+		return null;
+	}
+
+	return linkpath;
+}
+
+/**
+ * Rewrite a frontmatter image value so its linkpath is the file's full
+ * vault path, preserving the original shape (wikilink/embed markers,
+ * alias and size suffixes, plain paths). Obsidian's default link format
+ * is "shortest path when possible" ("[[cover.jpg]]"), which only the
+ * vault can resolve — published sites need the full path.
+ *
+ * resolveLinkpath maps a linkpath to its full vault path, or null when
+ * it doesn't resolve; unresolvable values are returned unchanged.
+ */
+export function resolveFrontmatterImageValue(
+	value: unknown,
+	resolveLinkpath: (linkpath: string) => string | null,
+): unknown {
+	const linkpath = getFrontmatterImageLinkpath(value);
+
+	if (!linkpath) {
+		return value;
+	}
+
+	const resolvedPath = resolveLinkpath(linkpath);
+
+	if (!resolvedPath || resolvedPath === linkpath) {
+		return value;
+	}
+
+	const trimmed = (value as string).trim();
+	const wikilink = trimmed.match(/^(!?)\[\[([^\]]+)\]\]$/);
+
+	if (wikilink) {
+		const suffixStart = wikilink[2].search(/[|#]/);
+		const suffix = suffixStart === -1 ? "" : wikilink[2].slice(suffixStart);
+
+		return `${wikilink[1]}[[${resolvedPath}${suffix}]]`;
+	}
+
+	return resolvedPath;
+}

--- a/src/dg-testVault/B Bases/Books/B5 Book with shortest-path cover.md
+++ b/src/dg-testVault/B Bases/Books/B5 Book with shortest-path cover.md
@@ -1,0 +1,9 @@
+---
+dg-publish: true
+tags:
+  - bases-cover-test
+cover: "[[travolta.png]]"
+year: 2023
+---
+
+Book note whose `cover` property is a shortest-path wikilink (just the filename), the format Obsidian writes with the default "shortest path when possible" link setting. The image actually lives at `A Assets/travolta.png`, so the published site must resolve the bare filename to show the thumbnail in [[B0 Cards with covers]].

--- a/src/publisher/PublishStatusManager.test.ts
+++ b/src/publisher/PublishStatusManager.test.ts
@@ -1,0 +1,113 @@
+import PublishStatusManager from "./PublishStatusManager";
+import DigitalGardenSiteManager from "../repositoryConnection/DigitalGardenSiteManager";
+import Publisher from "./Publisher";
+import { generateBlobHash } from "../utils/utils";
+import { CompiledPublishFile } from "../publishFile/PublishFile";
+
+const NOTE_PATH = "06 Assets/Lyrics/Bright Flight.md";
+const NOTE_CONTENT = "compiled note content";
+const COVER_PATH = "06 Assets/Blog/Album Covers/Bright Flight.jpg";
+
+const makeCompiledNote = (
+	path: string,
+	content: string,
+	imagePaths: string[],
+) =>
+	({
+		getPath: () => path,
+		compile: async function () {
+			return this;
+		},
+		getCompiledFile: () => [
+			content,
+			{
+				images: imagePaths.map((imagePath) => ({
+					path: imagePath,
+					content: "",
+				})),
+			},
+		],
+		setRemoteHash: () => {},
+		compare: () => 0,
+	}) as unknown as CompiledPublishFile & { compile: () => unknown };
+
+const makeManager = (options: {
+	remoteNoteHashes: Record<string, string>;
+	remoteImageHashes: Record<string, string>;
+	notes: unknown[];
+	images?: string[];
+}) => {
+	const siteManager = {
+		getUserGardenConnection: async () => ({
+			getContent: async () => ({ tree: [] }),
+		}),
+		getNoteHashes: async () => options.remoteNoteHashes,
+		getImageHashes: async () => options.remoteImageHashes,
+	} as unknown as DigitalGardenSiteManager;
+
+	const publisher = {
+		getFilesMarkedForPublishing: async () => ({
+			notes: options.notes,
+			images: options.images ?? [],
+		}),
+	} as unknown as Publisher;
+
+	return new PublishStatusManager(siteManager, publisher);
+};
+
+describe("getPublishStatus", () => {
+	it("treats an unchanged note with all images on the remote as published", async () => {
+		const note = makeCompiledNote(NOTE_PATH, NOTE_CONTENT, [COVER_PATH]);
+
+		const manager = makeManager({
+			remoteNoteHashes: { [NOTE_PATH]: generateBlobHash(NOTE_CONTENT) },
+			remoteImageHashes: { [COVER_PATH]: "some-sha" },
+			notes: [note],
+			images: [COVER_PATH],
+		});
+
+		const status = await manager.getPublishStatus();
+
+		expect(status.publishedNotes.map((f) => f.getPath())).toEqual([
+			NOTE_PATH,
+		]);
+		expect(status.changedNotes).toEqual([]);
+	});
+
+	it("treats an unchanged note as changed when a referenced image is missing from the remote", async () => {
+		// Regression: notes published before frontmatter covers were
+		// uploaded (< 2.80.2) never get their covers published, because
+		// the note itself hashes as unchanged and is skipped forever.
+		const note = makeCompiledNote(NOTE_PATH, NOTE_CONTENT, [COVER_PATH]);
+
+		const manager = makeManager({
+			remoteNoteHashes: { [NOTE_PATH]: generateBlobHash(NOTE_CONTENT) },
+			remoteImageHashes: {},
+			notes: [note],
+			images: [COVER_PATH],
+		});
+
+		const status = await manager.getPublishStatus();
+
+		expect(status.changedNotes.map((f) => f.getPath())).toEqual([
+			NOTE_PATH,
+		]);
+		expect(status.publishedNotes).toEqual([]);
+	});
+
+	it("still treats notes with different content as changed", async () => {
+		const note = makeCompiledNote(NOTE_PATH, NOTE_CONTENT, []);
+
+		const manager = makeManager({
+			remoteNoteHashes: { [NOTE_PATH]: generateBlobHash("old content") },
+			remoteImageHashes: {},
+			notes: [note],
+		});
+
+		const status = await manager.getPublishStatus();
+
+		expect(status.changedNotes.map((f) => f.getPath())).toEqual([
+			NOTE_PATH,
+		]);
+	});
+});

--- a/src/publisher/PublishStatusManager.ts
+++ b/src/publisher/PublishStatusManager.ts
@@ -65,14 +65,21 @@ export default class PublishStatusManager implements IPublishStatusManager {
 
 		for (const file of marked.notes) {
 			const compiledFile = await file.compile();
-			const [content, _] = compiledFile.getCompiledFile();
+			const [content, assets] = compiledFile.getCompiledFile();
 
 			const localHash = generateBlobHash(content);
 			const remoteHash = remoteNoteHashes[file.getPath()];
 
+			// A note whose referenced images never made it to the remote
+			// (e.g. frontmatter covers published with plugin < 2.80.2) is
+			// not fully published, even if the note text is unchanged.
+			const hasMissingRemoteImage = assets.images.some(
+				(image) => !remoteImageHashes[image.path],
+			);
+
 			if (!remoteHash) {
 				unpublishedNotes.push(compiledFile);
-			} else if (remoteHash === localHash) {
+			} else if (remoteHash === localHash && !hasMissingRemoteImage) {
 				compiledFile.setRemoteHash(remoteHash);
 				publishedNotes.push(compiledFile);
 			} else {


### PR DESCRIPTION
## Problem

Follow-up to #808/#809, from a user report: base card covers still 404 on a garden running 2.80.3 + template #390. Two gaps:

1. **Notes published before 2.80.2 never heal.** Their frontmatter covers were never uploaded (the old extension-check bug), and publish status only compares note text hashes — so an unchanged note is skipped forever and its cover can never appear without manually editing the note.
2. **Shortest-path wikilink values are published verbatim.** `cover: "[[AmericanWater.jpg]]"` (Obsidian's default *shortest path when possible* format) is uploaded to its full vault path, but the published `dg-note-properties` still carries the bare filename — the published data disagrees with where the plugin put the asset, and the site can only guess.

## Fix

**Commit 1 — publish status:** a hash-unchanged note whose compiled assets reference an image missing from the remote tree is now classified as *changed*. A normal batch publish then re-publishes it and uploads the missing cover. (Affected notes on the reporting garden: exactly the three albums whose covers 404.)

**Commit 2 — compile-time resolution:** the frontmatter compiler resolves image-shaped property values through the vault's own `getFirstLinkpathDest` when building `dg-note-properties`, preserving the value's shape (embed marker, `|300` suffixes, plain paths; note links and external URLs untouched). Linkpath detection moves to a shared `frontmatterImageLinks` module used by both the compiler and the asset-upload path, so the published value and the upload location cannot disagree. The plugin is now the resolution authority; the template keeps a lookup fallback only for content published by older versions (oleeskild/digitalgarden#392).

Also adds a shortest-path cover note to the test vault QA folder.

## Testing

- 10 new tests: publish-status classification (missing image ⇒ changed, all-present ⇒ published) and frontmatter resolution shapes; 115 total pass.
- `tsc --noEmit` clean, production bundle builds.

Companion template PR: oleeskild/digitalgarden#392

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFUucReuWzHi8VCKMovneB