### PR TITLE
chore: force nested svelte to patched 5.x via npm override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5933,14 +5933,6 @@
 				"tslib": "2.1.0"
 			}
 		},
-		"node_modules/obsidian-calendar-ui/node_modules/svelte": {
-			"version": "3.35.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.35.0.tgz",
-			"integrity": "sha512-gknlZkR2sXheu/X+B7dDImwANVvK1R0QGQLd8CNIfxxGPeXBmePnxfzb6fWwTQRsYQG7lYkZXvpXJvxvpsoB7g==",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/obsidian-calendar-ui/node_modules/tslib": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
@@ -6977,9 +6969,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.56.6",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.6.tgz",
-			"integrity": "sha512-p4HDLDogGHKRKCrgckQHNs5PEfXkju6JI5jTywueaKJI5hAdjPohEhRtQ0M1SWC/+TA73SPln+r7srr+7e4nZA==",
+			"version": "5.56.8",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.8.tgz",
+			"integrity": "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11720,15 +11712,10 @@
 			"integrity": "sha512-hdoRqCPnukfRgCARgArXaqMQZ+Iai0eY7f0ZsFHHfywpv4gKg3Tx5p47UsLvRO5DD+4knlbrL7Gel57MkfcLTw==",
 			"requires": {
 				"obsidian-daily-notes-interface": "0.8.4",
-				"svelte": "3.35.0",
+				"svelte": "^5.56.6",
 				"tslib": "2.1.0"
 			},
 			"dependencies": {
-				"svelte": {
-					"version": "3.35.0",
-					"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.35.0.tgz",
-					"integrity": "sha512-gknlZkR2sXheu/X+B7dDImwANVvK1R0QGQLd8CNIfxxGPeXBmePnxfzb6fWwTQRsYQG7lYkZXvpXJvxvpsoB7g=="
-				},
 				"tslib": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
@@ -12406,9 +12393,9 @@
 			"dev": true
 		},
 		"svelte": {
-			"version": "5.56.6",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.6.tgz",
-			"integrity": "sha512-p4HDLDogGHKRKCrgckQHNs5PEfXkju6JI5jTywueaKJI5hAdjPohEhRtQ0M1SWC/+TA73SPln+r7srr+7e4nZA==",
+			"version": "5.56.8",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.8.tgz",
+			"integrity": "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/remapping": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
 			"prettier --write",
 			"eslint --fix ."
 		]
+	},
+	"overrides": {
+		"svelte": "$svelte"
 	}
 }


### PR DESCRIPTION
All 9 open Dependabot alerts (1 high, 8 moderate — assorted svelte XSS advisories) resolve to a single `svelte@3.35.0` nested under `obsidian-dataview → obsidian-calendar-ui`. Updating the parent doesn't help: `obsidian-dataview@0.5.68` (latest) still pins `obsidian-calendar-ui@^0.3.12`, which pins svelte 3.x.

Fix: a top-level npm override (`"svelte": "$svelte"`) so every resolution uses our already-patched direct dependency (5.56.x ≥ 5.55.7, the highest patched version any alert requires). This is safe because the plugin only imports `DataviewApi`/`getAPI` from obsidian-dataview (`src/compiler/DataviewCompiler.ts:4`) — the calendar UI's svelte code never enters the bundle, as confirmed by the build.

Verified: Jest 115/115, `tsc --noEmit` clean, production build OK with the bundle check confirming all 16 of our own Svelte components present in `main.js`.

Companion template-repo PR for its dependabot alerts: oleeskild/digitalgarden#396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFUucReuWzHi8VCKMovneB