### PR TITLE
feat: convert markdown-style links to full-path wikilinks at publish

### DIFF
--- a/src/compiler/GardenPageCompiler.ts
+++ b/src/compiler/GardenPageCompiler.ts
@@ -172,6 +172,7 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 			this.createTranscludedText(0),
 			this.convertDataViews,
 			this.convertLinksToFullPath,
+			this.convertMarkdownLinksToFullPath,
 			this.removeObsidianComments,
 			this.createSvgEmbeds,
 		];
@@ -262,6 +263,7 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 			this.createTranscludedText(0),
 			this.convertDataViews,
 			this.convertLinksToFullPath,
+			this.convertMarkdownLinksToFullPath,
 			this.removeObsidianComments,
 			this.createSvgEmbeds,
 		];
@@ -453,6 +455,132 @@ export class GardenPageCompiler implements ITextNodeProcessor {
 					console.log(e);
 					continue;
 				}
+			}
+		}
+
+		return convertedText;
+	};
+
+	/**
+	 * Converts markdown-style links to vault files (e.g. [X](../a/b.md),
+	 * written by Obsidian's "relative"/"shortest path" markdown link formats
+	 * or by external tools) into full-path wikilinks, the same output as
+	 * convertLinksToFullPath. Published relative hrefs would otherwise break
+	 * under the site's trailing-slash URLs and stay invisible to the graph.
+	 */
+	convertMarkdownLinksToFullPath: TCompilerStep = (file) => async (text) => {
+		let convertedText = text;
+
+		const textToBeProcessed =
+			await this.stripAwayCodeFencesAndFrontmatter(file)(text);
+
+		const markdownLinkRegex =
+			/(?<!!)\[([^[\]]*)\]\(\s*([^)\s]+?\.(?:md|markdown|canvas))((?:#[^)\s]*)?)\s*\)/gi;
+
+		const decode = (value: string) => {
+			try {
+				return decodeURIComponent(value);
+			} catch {
+				return value;
+			}
+		};
+
+		// Resolve "./" and "../" against the source file's directory,
+		// since getFirstLinkpathDest expects vault-rooted link paths.
+		const resolveRelative = (target: string): string | null => {
+			const sourcePath = file.getPath();
+
+			const sourceDir = sourcePath.includes("/")
+				? sourcePath.substring(0, sourcePath.lastIndexOf("/"))
+				: "";
+
+			const segments: string[] = sourceDir ? sourceDir.split("/") : [];
+
+			for (const part of target.split("/")) {
+				if (part === "" || part === ".") continue;
+
+				if (part === "..") {
+					if (segments.length === 0) return null;
+					segments.pop();
+					continue;
+				}
+				segments.push(part);
+			}
+
+			return segments.join("/");
+		};
+
+		let match;
+
+		while ((match = markdownLinkRegex.exec(textToBeProcessed))) {
+			try {
+				const [fullMatch, displayText, rawTarget, rawFragment] = match;
+
+				if (/^[a-z][a-z0-9+.-]*:/i.test(rawTarget)) {
+					continue;
+				}
+
+				const target = decode(rawTarget);
+
+				const isExplicitRelative =
+					target.startsWith("./") || target.startsWith("../");
+
+				const relativeTarget = resolveRelative(target);
+
+				// Obsidian resolves markdown links against the vault
+				// (full path or unique basename) with the raw target;
+				// explicitly relative targets resolve against the file.
+				const candidates = isExplicitRelative
+					? [relativeTarget, target]
+					: [target, relativeTarget];
+
+				let linkedFile: TFile | null = null;
+
+				for (const candidate of candidates) {
+					if (candidate === null) continue;
+
+					linkedFile = this.metadataCache.getFirstLinkpathDest(
+						candidate,
+						file.getPath(),
+					);
+
+					if (linkedFile) break;
+				}
+
+				if (
+					!linkedFile ||
+					(linkedFile.extension !== "md" &&
+						linkedFile.extension !== "canvas")
+				) {
+					continue;
+				}
+
+				const extensionlessPath = linkedFile.path.substring(
+					0,
+					linkedFile.path.lastIndexOf("."),
+				);
+
+				// Keep .canvas extension in links for canvas files
+				const linkPath =
+					linkedFile.extension === "canvas"
+						? `${extensionlessPath}.canvas`
+						: extensionlessPath;
+
+				const headerPath = decode(rawFragment ?? "");
+
+				const linkDisplayName =
+					displayText ||
+					extensionlessPath.substring(
+						extensionlessPath.lastIndexOf("/") + 1,
+					);
+
+				convertedText = convertedText.replaceAll(
+					fullMatch,
+					`[[${linkPath}${headerPath}\\|${linkDisplayName}]]`,
+				);
+			} catch (e) {
+				console.log(e);
+				continue;
 			}
 		}
 

--- a/src/test/Compiler.test.ts
+++ b/src/test/Compiler.test.ts
@@ -113,6 +113,171 @@ describe("Compiler", () => {
 		});
 	});
 
+	describe("convertMarkdownLinksToFullPath", () => {
+		const sourcePath = "wiki/concepts/high-impact-practices.md";
+
+		const mockPublishFile = {
+			getPath: () => sourcePath,
+		} as unknown as PublishFile;
+
+		// Resolves like Obsidian: vault files addressed by full path,
+		// unique-basename lookup, or path relative to the source file.
+		const vaultFiles: Record<string, string> = {
+			"wiki/authors/andrade.md": "wiki/authors/andrade.md",
+			"../authors/andrade.md": "wiki/authors/andrade.md",
+			"feedback.md": "wiki/concepts/feedback.md",
+			"wiki/concepts/feedback.md": "wiki/concepts/feedback.md",
+			"My Note.md": "My Note.md",
+			"board.canvas": "wiki/board.canvas",
+		};
+
+		const getCompiler = () => {
+			return new GardenPageCompiler(
+				{} as Vault,
+				{ pathRewriteRules: "" } as DigitalGardenSettings,
+				{
+					getFirstLinkpathDest: jest.fn((linkpath: string) => {
+						const path = vaultFiles[linkpath];
+
+						if (!path) return null;
+
+						return {
+							path,
+							extension: path.substring(
+								path.lastIndexOf(".") + 1,
+							),
+						};
+					}),
+				} as unknown as MetadataCache,
+				jest.fn(),
+			);
+		};
+
+		it("converts a relative markdown link to a full-path wikilink", async () => {
+			const result = await getCompiler().convertMarkdownLinksToFullPath(
+				mockPublishFile,
+			)("See [Andrade](../authors/andrade.md) for details");
+
+			expect(result).toBe(
+				"See [[wiki/authors/andrade\\|Andrade]] for details",
+			);
+		});
+
+		it("converts a shortest-path markdown link via vault lookup", async () => {
+			const result = await getCompiler().convertMarkdownLinksToFullPath(
+				mockPublishFile,
+			)("See [Feedback](feedback.md)");
+
+			expect(result).toBe("See [[wiki/concepts/feedback\\|Feedback]]");
+		});
+
+		it("preserves and decodes header fragments", async () => {
+			const result = await getCompiler().convertMarkdownLinksToFullPath(
+				mockPublishFile,
+			)("[Model](feedback.md#The%20Model)");
+
+			expect(result).toBe("[[wiki/concepts/feedback#The Model\\|Model]]");
+		});
+
+		it("decodes URL-encoded link targets", async () => {
+			const result = await getCompiler().convertMarkdownLinksToFullPath(
+				mockPublishFile,
+			)("[Note](My%20Note.md)");
+
+			expect(result).toBe("[[My Note\\|Note]]");
+		});
+
+		it("keeps the .canvas extension for canvas links", async () => {
+			const result = await getCompiler().convertMarkdownLinksToFullPath(
+				mockPublishFile,
+			)("[Board](board.canvas)");
+
+			expect(result).toBe("[[wiki/board.canvas\\|Board]]");
+		});
+
+		it("resolves explicit relative paths even when the raw target has no vault match", async () => {
+			const compiler = new GardenPageCompiler(
+				{} as Vault,
+				{ pathRewriteRules: "" } as DigitalGardenSettings,
+				{
+					// Only resolves normalized vault-root paths, like a vault
+					// where getFirstLinkpathDest does not understand "../".
+					getFirstLinkpathDest: jest.fn((linkpath: string) =>
+						linkpath === "wiki/authors/andrade.md"
+							? {
+									path: "wiki/authors/andrade.md",
+									extension: "md",
+							  }
+							: null,
+					),
+				} as unknown as MetadataCache,
+				jest.fn(),
+			);
+
+			const result = await compiler.convertMarkdownLinksToFullPath(
+				mockPublishFile,
+			)("[Andrade](../authors/andrade.md)");
+
+			expect(result).toBe("[[wiki/authors/andrade\\|Andrade]]");
+		});
+
+		it("leaves external links untouched", async () => {
+			const text =
+				"[ext](https://example.com/a.md) [mail](mailto:a@b.md)";
+
+			const result =
+				await getCompiler().convertMarkdownLinksToFullPath(
+					mockPublishFile,
+				)(text);
+
+			expect(result).toBe(text);
+		});
+
+		it("leaves unresolved links untouched", async () => {
+			const text = "[missing](does/not/exist.md)";
+
+			const result =
+				await getCompiler().convertMarkdownLinksToFullPath(
+					mockPublishFile,
+				)(text);
+
+			expect(result).toBe(text);
+		});
+
+		it("leaves image embeds untouched", async () => {
+			const text = "![embed](../authors/andrade.md)";
+
+			const result =
+				await getCompiler().convertMarkdownLinksToFullPath(
+					mockPublishFile,
+				)(text);
+
+			expect(result).toBe(text);
+		});
+
+		it("leaves links inside code fences untouched", async () => {
+			const text = "```\n[Andrade](../authors/andrade.md)\n```";
+
+			const result =
+				await getCompiler().convertMarkdownLinksToFullPath(
+					mockPublishFile,
+				)(text);
+
+			expect(result).toBe(text);
+		});
+
+		it("does not touch non-md/canvas file links", async () => {
+			const text = "[doc](files/report.pdf)";
+
+			const result =
+				await getCompiler().convertMarkdownLinksToFullPath(
+					mockPublishFile,
+				)(text);
+
+			expect(result).toBe(text);
+		});
+	});
+
 	describe("convertEmbeddedAssets", () => {
 		const getCompilerWithImageFile = () => {
 			return new GardenPageCompiler(


### PR DESCRIPTION
## Problem

Notes written with markdown-style links: Obsidian's "relative to file" / "shortest path when possible" markdown link formats, or vaults generated by external tools (e.g. LLM-generated wikis) publish their links untouched. Downstream that means:

- Relative hrefs like `../concepts/x.md` resolve one directory too deep under the site's trailing-slash URLs (`/wiki/concepts/concepts/x.md` → 404). Reported by a Forestry customer whose whole wiki uses markdown links.
- The graph and backlinks never see these links, so notes appear as isolated dots.

The template side gained resolution for explicit relative paths in oleeskild/digitalgarden#398, but "shortest path" links (`[Feedback](feedback.md)` resolved by unique basename across the vault) can only be resolved where the vault is available, at publish time.

## Change

New compiler step `convertMarkdownLinksToFullPath`, running immediately after `convertLinksToFullPath` in both the note and canvas-text pipelines. It rewrites `[Display](target.md)` to `[[full/vault/path\|Display]]` — the same output as the wikilink step — so templates (old and new), the graph, and backlinks all handle the result with no further changes.

Resolution mirrors Obsidian's own behavior:

- Vault lookup via `metadataCache.getFirstLinkpathDest` (full path or unique basename)
- Explicit `./` / `../` targets normalized against the source file's directory, with sensible fallback ordering between the two strategies
- URL-encoded targets and header fragments decoded: `[Model](feedback.md#The%20Model)` → `[[wiki/concepts/feedback#The Model\|Model]]`
- `.canvas` targets keep their extension, matching the wikilink branch

Left untouched: external links, image embeds, links inside code fences (matching runs on fence/frontmatter-stripped text, same as the wikilink step), non-md/canvas targets, and unresolvable links (which fall through to the template's dead-link handling).