### PR TITLE
Garden plugin manager: install, browse, configure, and manage garden plugins

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,7 @@ import { DigitalGardenSettingTab } from "./src/views/DigitalGardenSettingTab";
 import Logger from "js-logger";
 import { PublishFile } from "./src/publishFile/PublishFile";
 import { FRONTMATTER_KEYS } from "./src/publishFile/FileMetaDataManager";
+import { InstallPluginModal } from "./src/views/GardenPluginSettings/InstallPluginModal";
 import { PublishPlatform } from "src/models/PublishPlatform";
 import { hasUpdates } from "./src/repositoryConnection/TemplateManager";
 import { LimitReachedError } from "src/forestry/LimitReachedError";
@@ -248,6 +249,15 @@ export default class DigitalGarden extends Plugin {
 			name: "Publish Active Note",
 			callback: async () => {
 				await this.publishSingleNote();
+			},
+		});
+
+		this.addCommand({
+			id: "install-garden-plugin",
+			name: "Install garden plugin from URL",
+			callback: async () => {
+				const modal = new InstallPluginModal(this.app, this.settings);
+				await modal.open();
 			},
 		});
 

--- a/src/gardenPlugins/GardenPluginManager.test.ts
+++ b/src/gardenPlugins/GardenPluginManager.test.ts
@@ -1,0 +1,480 @@
+import { Base64 } from "js-base64";
+import { GardenPluginManager } from "./GardenPluginManager";
+import { RepositoryConnection } from "src/repositoryConnection/RepositoryConnection";
+import DigitalGardenSettings from "src/models/settings";
+import { PublishPlatform } from "src/models/PublishPlatform";
+
+const makeSettings = (contentBaseDir = "") =>
+	({
+		contentBaseDir,
+		publishPlatform: PublishPlatform.SelfHosted,
+	}) as DigitalGardenSettings;
+
+const SEARCH_MANIFEST = {
+	id: "dg-search",
+	name: "Search",
+	version: "1.0.0",
+	description: "Site search",
+	author: "Ole",
+	noteSettings: ["dgEnableSearch"],
+};
+
+const COMMUNITY_MANIFEST = {
+	id: "comments",
+	name: "Comments",
+	version: "2.0.0",
+	description: "Comments under notes",
+	author: "Jane",
+	settings: [{ key: "repo", name: "Repo", type: "text", default: "" }],
+};
+
+interface IFakeUserRepo {
+	files: Record<string, string>;
+	updateCalls: { path: string; content: string; sha?: string }[];
+	commitCalls: {
+		additions?: { path: string; content: string }[];
+		deletions?: string[];
+		message: string;
+	}[];
+}
+
+const makeUserConnection = (repo: IFakeUserRepo) =>
+	({
+		getContent: async () => ({
+			tree: Object.entries(repo.files).map(([path, content]) => ({
+				path,
+				type: "blob",
+				sha: `sha-${path}`,
+				size: content.length,
+			})),
+		}),
+		getFile: async (path: string) => {
+			if (!(path in repo.files)) {
+				throw new Error(`Could not get file ${path}`);
+			}
+
+			return {
+				content: Base64.encode(repo.files[path]),
+				sha: `sha-${path}`,
+			};
+		},
+		updateFile: async (payload: {
+			path: string;
+			content: string;
+			sha?: string;
+		}) => {
+			repo.updateCalls.push(payload);
+			repo.files[payload.path] = Base64.decode(payload.content);
+
+			return { status: 200 };
+		},
+		commitChanges: async (payload: IFakeUserRepo["commitCalls"][0]) => {
+			repo.commitCalls.push(payload);
+
+			for (const addition of payload.additions ?? []) {
+				repo.files[addition.path] = Base64.decode(addition.content);
+			}
+
+			for (const deletion of payload.deletions ?? []) {
+				delete repo.files[deletion];
+			}
+		},
+	}) as unknown as RepositoryConnection;
+
+const makeFakeRepo = (files: Record<string, string> = {}): IFakeUserRepo => ({
+	files,
+	updateCalls: [],
+	commitCalls: [],
+});
+
+const makeSourceConnection = (source: {
+	files: Record<string, string>;
+	releaseTag?: string;
+}) =>
+	(() =>
+		({
+			getLatestRelease: async () =>
+				source.releaseTag ? { tag_name: source.releaseTag } : undefined,
+			getRepositoryInfo: async () => ({ default_branch: "main" }),
+			getContent: async () => ({
+				tree: Object.entries(source.files).map(([path, content]) => ({
+					path,
+					type: "blob",
+					sha: `blob-${path}`,
+					size: content.length,
+				})),
+			}),
+			getFile: async (path: string) => ({
+				content: Base64.encode(source.files[path]),
+				sha: `blob-${path}`,
+			}),
+			getBlob: async (sha: string) => {
+				const entry = Object.entries(source.files).find(
+					([path]) => `blob-${path}` === sha,
+				);
+
+				return entry ? Base64.encode(entry[1]) : undefined;
+			},
+		}) as unknown as RepositoryConnection) as (
+		owner: string,
+		repo: string,
+	) => RepositoryConnection;
+
+describe.each([{ base: "" }, { base: "Web/" }])(
+	"GardenPluginManager (contentBaseDir: '$base')",
+	({ base }) => {
+		const settings = makeSettings(base);
+
+		describe("listInstalled", () => {
+			it("enumerates plugins from the repo tree and merges registry state", async () => {
+				const repo = makeFakeRepo({
+					[`${base}src/plugins/dg-search/garden-plugin.json`]:
+						JSON.stringify(SEARCH_MANIFEST),
+					[`${base}src/plugins/comments/garden-plugin.json`]:
+						JSON.stringify(COMMUNITY_MANIFEST),
+					[`${base}src/plugins/plugins.json`]: JSON.stringify({
+						version: 1,
+						plugins: { "dg-search": { enabled: false } },
+					}),
+				});
+
+				const manager = new GardenPluginManager(
+					makeUserConnection(repo),
+					settings,
+				);
+
+				const plugins = await manager.listInstalled();
+
+				expect(plugins.map((p) => p.manifest.id)).toEqual([
+					"comments",
+					"dg-search",
+				]);
+
+				const search = plugins.find(
+					(p) => p.manifest.id === "dg-search",
+				);
+				expect(search?.enabled).toBe(false);
+				expect(search?.isFirstParty).toBe(true);
+
+				const comments = plugins.find(
+					(p) => p.manifest.id === "comments",
+				);
+				expect(comments?.enabled).toBe(true);
+				expect(comments?.isFirstParty).toBe(false);
+			});
+
+			it("skips invalid manifests and nested manifest files", async () => {
+				const repo = makeFakeRepo({
+					[`${base}src/plugins/broken/garden-plugin.json`]:
+						"{ not json",
+					[`${base}src/plugins/deep/nested/garden-plugin.json`]:
+						JSON.stringify(COMMUNITY_MANIFEST),
+					[`${base}src/plugins/comments/garden-plugin.json`]:
+						JSON.stringify(COMMUNITY_MANIFEST),
+				});
+
+				const manager = new GardenPluginManager(
+					makeUserConnection(repo),
+					settings,
+				);
+
+				const plugins = await manager.listInstalled();
+
+				expect(plugins.map((p) => p.manifest.id)).toEqual(["comments"]);
+			});
+
+			it("treats a malformed registry as absent", async () => {
+				const repo = makeFakeRepo({
+					[`${base}src/plugins/comments/garden-plugin.json`]:
+						JSON.stringify(COMMUNITY_MANIFEST),
+					[`${base}src/plugins/plugins.json`]: "also { not json",
+				});
+
+				const manager = new GardenPluginManager(
+					makeUserConnection(repo),
+					settings,
+				);
+
+				const plugins = await manager.listInstalled();
+
+				expect(plugins[0].enabled).toBe(true);
+			});
+		});
+
+		describe("setEnabled", () => {
+			it("writes the flag into the registry preserving other entries", async () => {
+				const repo = makeFakeRepo({
+					[`${base}src/plugins/plugins.json`]: JSON.stringify({
+						version: 1,
+						plugins: { other: { enabled: false } },
+					}),
+				});
+
+				const manager = new GardenPluginManager(
+					makeUserConnection(repo),
+					settings,
+				);
+
+				await manager.setEnabled("dg-search", false);
+
+				expect(repo.updateCalls).toHaveLength(1);
+
+				expect(repo.updateCalls[0].path).toBe(
+					`${base}src/plugins/plugins.json`,
+				);
+
+				const written = JSON.parse(
+					repo.files[`${base}src/plugins/plugins.json`],
+				);
+				expect(written.plugins["dg-search"].enabled).toBe(false);
+				expect(written.plugins.other.enabled).toBe(false);
+			});
+
+			it("creates the registry when none exists", async () => {
+				const repo = makeFakeRepo();
+
+				const manager = new GardenPluginManager(
+					makeUserConnection(repo),
+					settings,
+				);
+
+				await manager.setEnabled("comments", true);
+
+				const written = JSON.parse(
+					repo.files[`${base}src/plugins/plugins.json`],
+				);
+				expect(written.plugins.comments.enabled).toBe(true);
+			});
+		});
+
+		describe("inspectRemotePlugin and install", () => {
+			const sourceFiles = {
+				"garden-plugin.json": JSON.stringify(COMMUNITY_MANIFEST),
+				"templates/comments.njk": "<div>comments</div>",
+				".github/workflows/ci.yml": "ci",
+			};
+
+			it("fetches, validates, and installs in one commit", async () => {
+				const repo = makeFakeRepo();
+
+				const manager = new GardenPluginManager(
+					makeUserConnection(repo),
+					settings,
+					makeSourceConnection({
+						files: sourceFiles,
+						releaseTag: "v2.0.0",
+					}),
+				);
+
+				const remote = await manager.inspectRemotePlugin(
+					"https://github.com/jane/garden-plugin-comments",
+				);
+
+				expect(remote.ref).toBe("v2.0.0");
+				expect(remote.manifest.id).toBe("comments");
+
+				expect(remote.files.map((f) => f.path).sort()).toEqual([
+					"garden-plugin.json",
+					"templates/comments.njk",
+				]);
+
+				await manager.install(remote);
+
+				expect(repo.commitCalls).toHaveLength(1);
+				const commit = repo.commitCalls[0];
+
+				expect(commit.message).toBe(
+					"Install garden plugin comments (2.0.0)",
+				);
+
+				expect(commit.additions?.map((a) => a.path).sort()).toEqual([
+					`${base}src/plugins/comments/garden-plugin.json`,
+					`${base}src/plugins/comments/templates/comments.njk`,
+					`${base}src/plugins/plugins.json`,
+				]);
+
+				const registry = JSON.parse(
+					repo.files[`${base}src/plugins/plugins.json`],
+				);
+				const entry = registry.plugins.comments;
+				expect(entry.repo).toBe("jane/garden-plugin-comments");
+				expect(entry.installedVersion).toBe("2.0.0");
+				expect(entry.installedRef).toBe("v2.0.0");
+				expect(entry.enabled).toBe(true);
+
+				expect(entry.files).toEqual([
+					`${base}src/plugins/comments/garden-plugin.json`,
+					`${base}src/plugins/comments/templates/comments.njk`,
+				]);
+			});
+
+			it("falls back to the default branch when there is no release", async () => {
+				const manager = new GardenPluginManager(
+					makeUserConnection(makeFakeRepo()),
+					settings,
+					makeSourceConnection({ files: sourceFiles }),
+				);
+
+				const remote =
+					await manager.inspectRemotePlugin("jane/comments");
+
+				expect(remote.ref).toBe("main");
+			});
+
+			it("rejects a repo without a manifest", async () => {
+				const manager = new GardenPluginManager(
+					makeUserConnection(makeFakeRepo()),
+					settings,
+					makeSourceConnection({ files: { "README.md": "hi" } }),
+				);
+
+				await expect(
+					manager.inspectRemotePlugin("jane/not-a-plugin"),
+				).rejects.toThrow(/no garden-plugin.json/);
+			});
+
+			it("rejects a manifest with a reserved id", async () => {
+				const manager = new GardenPluginManager(
+					makeUserConnection(makeFakeRepo()),
+					settings,
+					makeSourceConnection({
+						files: {
+							"garden-plugin.json":
+								JSON.stringify(SEARCH_MANIFEST),
+						},
+					}),
+				);
+
+				await expect(
+					manager.inspectRemotePlugin("jane/fake-search"),
+				).rejects.toThrow(/reserved/);
+			});
+
+			it("disables handed-over plugins in the same install commit", async () => {
+				const repo = makeFakeRepo();
+
+				const manager = new GardenPluginManager(
+					makeUserConnection(repo),
+					settings,
+					makeSourceConnection({
+						files: sourceFiles,
+						releaseTag: "v2.0.0",
+					}),
+				);
+
+				const remote =
+					await manager.inspectRemotePlugin("jane/comments");
+
+				await manager.install(remote, undefined, ["dg-filetree"]);
+
+				expect(repo.commitCalls).toHaveLength(1);
+
+				const registry = JSON.parse(
+					repo.files[`${base}src/plugins/plugins.json`],
+				);
+				expect(registry.plugins["dg-filetree"].enabled).toBe(false);
+				expect(registry.plugins.comments.enabled).toBe(true);
+			});
+
+			it("deletes orphaned files on update", async () => {
+				const repo = makeFakeRepo();
+
+				const manager = new GardenPluginManager(
+					makeUserConnection(repo),
+					settings,
+					makeSourceConnection({
+						files: sourceFiles,
+						releaseTag: "v2.0.0",
+					}),
+				);
+
+				const remote =
+					await manager.inspectRemotePlugin("jane/comments");
+
+				await manager.install(remote, {
+					enabled: false,
+					files: [
+						`${base}src/plugins/comments/garden-plugin.json`,
+						`${base}src/plugins/comments/old-file.js`,
+					],
+				});
+
+				const commit = repo.commitCalls[0];
+
+				expect(commit.deletions).toEqual([
+					`${base}src/plugins/comments/old-file.js`,
+				]);
+
+				expect(commit.message).toBe(
+					"Update garden plugin comments (2.0.0)",
+				);
+
+				const registry = JSON.parse(
+					repo.files[`${base}src/plugins/plugins.json`],
+				);
+				expect(registry.plugins.comments.enabled).toBe(false);
+			});
+		});
+
+		describe("uninstall", () => {
+			it("removes recorded files and the registry entry in one commit", async () => {
+				const repo = makeFakeRepo({
+					[`${base}src/plugins/comments/garden-plugin.json`]:
+						JSON.stringify(COMMUNITY_MANIFEST),
+					[`${base}src/plugins/plugins.json`]: JSON.stringify({
+						version: 1,
+						plugins: {
+							comments: {
+								files: [
+									`${base}src/plugins/comments/garden-plugin.json`,
+								],
+							},
+							other: { enabled: false },
+						},
+					}),
+				});
+
+				const manager = new GardenPluginManager(
+					makeUserConnection(repo),
+					settings,
+				);
+
+				const [plugin] = await manager.listInstalled();
+				await manager.uninstall(plugin);
+
+				const commit = repo.commitCalls[0];
+
+				expect(commit.deletions).toEqual([
+					`${base}src/plugins/comments/garden-plugin.json`,
+				]);
+
+				const registry = JSON.parse(
+					repo.files[`${base}src/plugins/plugins.json`],
+				);
+				expect(registry.plugins.comments).toBeUndefined();
+				expect(registry.plugins.other).toBeDefined();
+			});
+
+			it("enumerates the plugin directory when the registry has no file list", async () => {
+				const repo = makeFakeRepo({
+					[`${base}src/plugins/comments/garden-plugin.json`]:
+						JSON.stringify(COMMUNITY_MANIFEST),
+					[`${base}src/plugins/comments/templates/x.njk`]: "x",
+				});
+
+				const manager = new GardenPluginManager(
+					makeUserConnection(repo),
+					settings,
+				);
+
+				const [plugin] = await manager.listInstalled();
+				await manager.uninstall(plugin);
+
+				expect(repo.commitCalls[0].deletions?.sort()).toEqual([
+					`${base}src/plugins/comments/garden-plugin.json`,
+					`${base}src/plugins/comments/templates/x.njk`,
+				]);
+			});
+		});
+	},
+);

--- a/src/gardenPlugins/GardenPluginManager.ts
+++ b/src/gardenPlugins/GardenPluginManager.ts
@@ -49,7 +49,7 @@ type PathSettings = Pick<
  * plugin directories under src/plugins/ and the user-owned registry file
  * src/plugins/plugins.json. The repo is the source of truth — nothing is
  * cached in plugin settings. Installation never executes plugin code; it
- * only copies files (see docs/PLUGIN_INSTALLER_SPEC.md in the template).
+ * only copies files.
  */
 export class GardenPluginManager {
 	constructor(

--- a/src/gardenPlugins/GardenPluginManager.ts
+++ b/src/gardenPlugins/GardenPluginManager.ts
@@ -1,0 +1,476 @@
+import axios from "axios";
+import { Base64 } from "js-base64";
+import Logger from "js-logger";
+import { RepositoryConnection } from "src/repositoryConnection/RepositoryConnection";
+import PublishPlatformConnectionFactory from "src/repositoryConnection/PublishPlatformConnectionFactory";
+import DigitalGardenSettings from "src/models/settings";
+import {
+	CommunityGardenPlugin,
+	GardenPluginManifest,
+	GardenPluginRegistry,
+	GardenPluginRegistryEntry,
+	InstalledGardenPlugin,
+} from "src/models/gardenPlugin";
+import {
+	gardenPluginsPathBase,
+	gardenPluginsRegistryPath,
+} from "src/publisher/paths";
+import {
+	GARDEN_PLUGIN_MANIFEST_NAME,
+	MAX_PLUGIN_FILE_SIZE,
+	MAX_PLUGIN_TOTAL_SIZE,
+	parseGitHubRepoInput,
+	shouldSkipRepoFile,
+	validateGardenPluginManifest,
+} from "./manifest";
+
+const logger = Logger.get("garden-plugin-manager");
+
+export const COMMUNITY_PLUGINS_URL =
+	"https://raw.githubusercontent.com/oleeskild/digitalgarden-plugins/main/community-plugins.json";
+
+/** A plugin fetched and validated from its source repo, ready to install. */
+export interface RemoteGardenPlugin {
+	owner: string;
+	repo: string;
+	ref: string;
+	manifest: GardenPluginManifest;
+	/** Repo-relative source paths of every file to copy. */
+	files: { path: string; size: number; sha: string }[];
+}
+
+type PathSettings = Pick<
+	DigitalGardenSettings,
+	"contentBaseDir" | "publishPlatform"
+>;
+
+/**
+ * Reads and mutates the garden plugin state of a user's garden repo: the
+ * plugin directories under src/plugins/ and the user-owned registry file
+ * src/plugins/plugins.json. The repo is the source of truth — nothing is
+ * cached in plugin settings. Installation never executes plugin code; it
+ * only copies files (see docs/PLUGIN_INSTALLER_SPEC.md in the template).
+ */
+export class GardenPluginManager {
+	constructor(
+		private userGardenConnection: RepositoryConnection,
+		private settings: PathSettings,
+		/** Overridable in tests; defaults to an unauthenticated GitHub connection. */
+		private createSourceConnection: (
+			owner: string,
+			repo: string,
+		) => RepositoryConnection = (owner, repo) =>
+			new RepositoryConnection(
+				PublishPlatformConnectionFactory.createGitHubConnection(
+					owner,
+					repo,
+				),
+			),
+	) {}
+
+	private get pluginsBase() {
+		return gardenPluginsPathBase(this.settings);
+	}
+
+	private get registryPath() {
+		return gardenPluginsRegistryPath(this.settings);
+	}
+
+	/** Read the registry, tolerating a missing or malformed file. */
+	async getRegistry(): Promise<{
+		registry: GardenPluginRegistry;
+		sha?: string;
+	}> {
+		try {
+			const file = await this.userGardenConnection.getFile(
+				this.registryPath,
+			);
+
+			if (!file) {
+				return { registry: { version: 1, plugins: {} } };
+			}
+
+			const parsed = JSON.parse(Base64.decode(file.content));
+
+			if (
+				typeof parsed?.plugins !== "object" ||
+				parsed.plugins === null
+			) {
+				return { registry: { version: 1, plugins: {} }, sha: file.sha };
+			}
+
+			return {
+				registry: { version: 1, ...parsed },
+				sha: file.sha,
+			};
+		} catch {
+			// Missing file is the normal state for gardens without plugins.
+			return { registry: { version: 1, plugins: {} } };
+		}
+	}
+
+	private serializeRegistry(registry: GardenPluginRegistry): string {
+		return Base64.encode(JSON.stringify(registry, null, 2));
+	}
+
+	private async writeRegistry(
+		mutate: (registry: GardenPluginRegistry) => void,
+		message: string,
+	): Promise<void> {
+		const { registry, sha } = await this.getRegistry();
+
+		mutate(registry);
+
+		const response = await this.userGardenConnection.updateFile({
+			path: this.registryPath,
+			content: this.serializeRegistry(registry),
+			sha,
+			message,
+		});
+
+		if (!response) {
+			throw new Error("Could not update the plugin registry");
+		}
+	}
+
+	/**
+	 * Enumerate installed plugins from the garden repo: every
+	 * src/plugins/<id>/garden-plugin.json in the tree, merged with the
+	 * registry's enabled state and settings.
+	 */
+	async listInstalled(): Promise<InstalledGardenPlugin[]> {
+		const tree = await this.userGardenConnection.getContent("HEAD");
+
+		if (!tree) {
+			throw new Error("Could not read the garden repository");
+		}
+
+		const manifestPaths = (tree.tree ?? []).filter(
+			(item): item is { path: string; type: string } =>
+				typeof item.path === "string" &&
+				item.type === "blob" &&
+				item.path.startsWith(this.pluginsBase) &&
+				item.path.endsWith(`/${GARDEN_PLUGIN_MANIFEST_NAME}`) &&
+				item.path.slice(this.pluginsBase.length).split("/").length ===
+					2,
+		);
+
+		const { registry } = await this.getRegistry();
+		const plugins: InstalledGardenPlugin[] = [];
+
+		for (const item of manifestPaths) {
+			try {
+				const file = await this.userGardenConnection.getFile(item.path);
+
+				if (!file) {
+					continue;
+				}
+
+				const { manifest, errors } = validateGardenPluginManifest(
+					JSON.parse(Base64.decode(file.content)),
+					{ allowFirstParty: true },
+				);
+
+				if (!manifest) {
+					logger.warn(
+						`Skipping invalid plugin manifest at ${
+							item.path
+						}: ${errors.join(", ")}`,
+					);
+					continue;
+				}
+
+				const registryEntry = registry.plugins[manifest.id];
+
+				plugins.push({
+					manifest,
+					registryEntry,
+					enabled: registryEntry?.enabled !== false,
+					isFirstParty: manifest.id.startsWith("dg-"),
+				});
+			} catch (error) {
+				logger.warn(
+					`Skipping unreadable plugin at ${item.path}`,
+					error,
+				);
+			}
+		}
+
+		return plugins.sort((a, b) =>
+			a.manifest.id.localeCompare(b.manifest.id),
+		);
+	}
+
+	async setEnabled(id: string, enabled: boolean): Promise<void> {
+		await this.writeRegistry(
+			(registry) => {
+				registry.plugins[id] = { ...registry.plugins[id], enabled };
+			},
+			`${enabled ? "Enable" : "Disable"} garden plugin ${id}`,
+		);
+	}
+
+	async savePluginSettings(
+		id: string,
+		values: Record<string, string | number | boolean>,
+	): Promise<void> {
+		await this.writeRegistry((registry) => {
+			registry.plugins[id] = {
+				...registry.plugins[id],
+				settings: values,
+			};
+		}, `Update settings for garden plugin ${id}`);
+	}
+
+	/** Fetch the community plugin list. Returns [] when unavailable. */
+	async fetchCommunityPlugins(): Promise<CommunityGardenPlugin[]> {
+		try {
+			const response = await axios.get<CommunityGardenPlugin[]>(
+				COMMUNITY_PLUGINS_URL,
+			);
+
+			if (!Array.isArray(response.data)) {
+				return [];
+			}
+
+			return response.data.filter(
+				(entry) => entry && entry.id && entry.repo,
+			);
+		} catch (error) {
+			logger.info("Community plugin registry not reachable", error);
+
+			return [];
+		}
+	}
+
+	/**
+	 * Fetch and validate a plugin from a GitHub repo without writing
+	 * anything — the result is shown to the user for confirmation before
+	 * {@link install}. Throws with a readable message on any problem.
+	 */
+	async inspectRemotePlugin(repoInput: string): Promise<RemoteGardenPlugin> {
+		const parsed = parseGitHubRepoInput(repoInput);
+
+		if (!parsed) {
+			throw new Error(
+				"Could not parse that as a GitHub repository. Expected something like https://github.com/user/repo",
+			);
+		}
+
+		const source = this.createSourceConnection(parsed.owner, parsed.repo);
+
+		const release = await source.getLatestRelease();
+		let ref = release?.tag_name;
+
+		if (!ref) {
+			const info = await source.getRepositoryInfo();
+			ref = info?.default_branch ?? "HEAD";
+		}
+
+		const tree = await source.getContent(ref);
+
+		if (!tree) {
+			throw new Error(
+				`Could not read ${parsed.owner}/${parsed.repo}. Is it a public repository?`,
+			);
+		}
+
+		const hasManifest = (tree.tree ?? []).some(
+			(item) =>
+				item.path === GARDEN_PLUGIN_MANIFEST_NAME &&
+				item.type === "blob",
+		);
+
+		if (!hasManifest) {
+			throw new Error(
+				`${parsed.owner}/${parsed.repo} has no ${GARDEN_PLUGIN_MANIFEST_NAME} at its root, so it is not a garden plugin`,
+			);
+		}
+
+		const manifestFile = await source.getFile(
+			GARDEN_PLUGIN_MANIFEST_NAME,
+			ref,
+		);
+
+		if (!manifestFile) {
+			throw new Error(`Could not read ${GARDEN_PLUGIN_MANIFEST_NAME}`);
+		}
+
+		let manifestJson: unknown;
+
+		try {
+			manifestJson = JSON.parse(Base64.decode(manifestFile.content));
+		} catch {
+			throw new Error(`${GARDEN_PLUGIN_MANIFEST_NAME} is not valid JSON`);
+		}
+
+		const { manifest, errors } = validateGardenPluginManifest(manifestJson);
+
+		if (!manifest) {
+			throw new Error(`Invalid plugin manifest: ${errors.join("; ")}`);
+		}
+
+		const files = (tree.tree ?? [])
+			.filter(
+				(
+					item,
+				): item is {
+					path: string;
+					type: string;
+					size?: number;
+					sha: string;
+				} =>
+					typeof item.path === "string" &&
+					typeof item.sha === "string" &&
+					item.type === "blob" &&
+					!shouldSkipRepoFile(item.path),
+			)
+			.map((item) => ({
+				path: item.path,
+				size: item.size ?? 0,
+				sha: item.sha,
+			}));
+
+		const oversized = files.find(
+			(file) => file.size > MAX_PLUGIN_FILE_SIZE,
+		);
+
+		if (oversized) {
+			throw new Error(
+				`${oversized.path} is larger than the ${
+					MAX_PLUGIN_FILE_SIZE / 1024 / 1024
+				} MB per-file limit`,
+			);
+		}
+
+		const totalSize = files.reduce((sum, file) => sum + file.size, 0);
+
+		if (totalSize > MAX_PLUGIN_TOTAL_SIZE) {
+			throw new Error(
+				`The plugin is larger than the ${
+					MAX_PLUGIN_TOTAL_SIZE / 1024 / 1024
+				} MB limit`,
+			);
+		}
+
+		return {
+			owner: parsed.owner,
+			repo: parsed.repo,
+			ref,
+			manifest,
+			files,
+		};
+	}
+
+	private targetPathFor(id: string, sourcePath: string): string {
+		return `${this.pluginsBase}${id}/${sourcePath}`;
+	}
+
+	/**
+	 * Copy a validated remote plugin into the garden repo and record it in
+	 * the registry — one atomic commit for the files plus registry. When an
+	 * entry with previously installed files exists (update), files that no
+	 * longer exist at the new ref are deleted in the same commit.
+	 * `disablePluginIds` marks other plugins disabled in that same commit —
+	 * used to hand over an exclusive region (e.g. navigation) to the
+	 * incoming plugin.
+	 */
+	async install(
+		remote: RemoteGardenPlugin,
+		existingEntry?: GardenPluginRegistryEntry,
+		disablePluginIds: string[] = [],
+	): Promise<void> {
+		const source = this.createSourceConnection(remote.owner, remote.repo);
+
+		const additions: { path: string; content: string }[] = [];
+
+		for (const file of remote.files) {
+			const content = await source.getBlob(file.sha);
+
+			if (content === undefined) {
+				throw new Error(`Could not fetch ${file.path}`);
+			}
+
+			additions.push({
+				path: this.targetPathFor(remote.manifest.id, file.path),
+				content: content.replace(/\n/g, ""),
+			});
+		}
+
+		const newFilePaths = additions.map((addition) => addition.path);
+
+		const deletions = (existingEntry?.files ?? []).filter(
+			(path) => !newFilePaths.includes(path),
+		);
+
+		const { registry } = await this.getRegistry();
+
+		registry.plugins[remote.manifest.id] = {
+			...existingEntry,
+			repo: `${remote.owner}/${remote.repo}`,
+			installedVersion: remote.manifest.version,
+			installedRef: remote.ref,
+			installedAt: new Date().toISOString(),
+			enabled: existingEntry?.enabled !== false,
+			files: newFilePaths,
+		};
+
+		for (const id of disablePluginIds) {
+			if (id === remote.manifest.id) {
+				continue;
+			}
+
+			registry.plugins[id] = { ...registry.plugins[id], enabled: false };
+		}
+
+		additions.push({
+			path: this.registryPath,
+			content: this.serializeRegistry(registry),
+		});
+
+		const action = existingEntry ? "Update" : "Install";
+
+		await this.userGardenConnection.commitChanges({
+			additions,
+			deletions,
+			message: `${action} garden plugin ${remote.manifest.id} (${remote.manifest.version})`,
+		});
+	}
+
+	/**
+	 * Delete a community plugin's files and registry entry in one commit.
+	 * Falls back to enumerating the plugin directory when the registry has
+	 * no file list (e.g. manually installed plugins).
+	 */
+	async uninstall(plugin: InstalledGardenPlugin): Promise<void> {
+		const id = plugin.manifest.id;
+		let files = plugin.registryEntry?.files;
+
+		if (!files || files.length === 0) {
+			const tree = await this.userGardenConnection.getContent("HEAD");
+
+			files = (tree?.tree ?? [])
+				.filter(
+					(item): item is { path: string; type: string } =>
+						typeof item.path === "string" &&
+						item.type === "blob" &&
+						item.path.startsWith(`${this.pluginsBase}${id}/`),
+				)
+				.map((item) => item.path);
+		}
+
+		const { registry } = await this.getRegistry();
+		delete registry.plugins[id];
+
+		await this.userGardenConnection.commitChanges({
+			additions: [
+				{
+					path: this.registryPath,
+					content: this.serializeRegistry(registry),
+				},
+			],
+			deletions: files,
+			message: `Uninstall garden plugin ${id}`,
+		});
+	}
+}

--- a/src/gardenPlugins/manifest.test.ts
+++ b/src/gardenPlugins/manifest.test.ts
@@ -1,0 +1,145 @@
+import {
+	isSafePluginPath,
+	parseGitHubRepoInput,
+	shouldSkipRepoFile,
+	validateGardenPluginManifest,
+} from "./manifest";
+
+describe("parseGitHubRepoInput", () => {
+	it.each([
+		["owner/repo", "owner", "repo"],
+		["https://github.com/owner/repo", "owner", "repo"],
+		["http://github.com/owner/repo", "owner", "repo"],
+		["https://www.github.com/owner/repo", "owner", "repo"],
+		["https://github.com/owner/repo.git", "owner", "repo"],
+		["https://github.com/owner/repo/", "owner", "repo"],
+		["https://github.com/owner/repo/tree/main/src", "owner", "repo"],
+		["git@github.com:owner/repo.git", "owner", "repo"],
+		["  owner/repo  ", "owner", "repo"],
+	])("parses %s", (input, owner, repo) => {
+		expect(parseGitHubRepoInput(input)).toEqual({ owner, repo });
+	});
+
+	it.each([
+		[""],
+		["   "],
+		["just-a-name"],
+		["https://gitlab.com/owner/repo"],
+		["https://evil.com/owner/repo"],
+	])("rejects %s", (input) => {
+		expect(parseGitHubRepoInput(input)).toBeUndefined();
+	});
+});
+
+describe("isSafePluginPath", () => {
+	it.each([["templates/foo.njk"], ["index.js"], ["assets/"], ["a/b/c.css"]])(
+		"accepts %s",
+		(path) => {
+			expect(isSafePluginPath(path)).toBe(true);
+		},
+	);
+
+	it.each([
+		[""],
+		["/abs/path.js"],
+		["../escape.js"],
+		["a/../../b.js"],
+		["a/./b.js"],
+		["a//b.js"],
+		["a\\b.js"],
+	])("rejects %s", (path) => {
+		expect(isSafePluginPath(path)).toBe(false);
+	});
+});
+
+const validManifest = {
+	id: "my-plugin",
+	name: "My Plugin",
+	version: "1.0.0",
+	description: "Does things",
+	author: "Someone",
+};
+
+describe("validateGardenPluginManifest", () => {
+	it("accepts a minimal valid manifest", () => {
+		const { manifest, errors } =
+			validateGardenPluginManifest(validManifest);
+
+		expect(errors).toEqual([]);
+		expect(manifest?.id).toBe("my-plugin");
+	});
+
+	it("rejects a manifest with missing required fields", () => {
+		const { manifest, errors } = validateGardenPluginManifest({
+			id: "my-plugin",
+		});
+
+		expect(manifest).toBeUndefined();
+		expect(errors.join()).toContain("name");
+		expect(errors.join()).toContain("version");
+	});
+
+	it("rejects non-object input", () => {
+		expect(validateGardenPluginManifest(null).manifest).toBeUndefined();
+		expect(validateGardenPluginManifest("hi").manifest).toBeUndefined();
+	});
+
+	it("rejects invalid ids", () => {
+		const { manifest } = validateGardenPluginManifest({
+			...validManifest,
+			id: "My Plugin!",
+		});
+
+		expect(manifest).toBeUndefined();
+	});
+
+	it("rejects the reserved dg- prefix unless allowFirstParty", () => {
+		const reserved = { ...validManifest, id: "dg-search" };
+
+		expect(validateGardenPluginManifest(reserved).manifest).toBeUndefined();
+
+		expect(
+			validateGardenPluginManifest(reserved, { allowFirstParty: true })
+				.manifest,
+		).toBeDefined();
+	});
+
+	it("rejects unsafe declared paths", () => {
+		const { manifest, errors } = validateGardenPluginManifest({
+			...validManifest,
+			styles: ["../../evil.scss"],
+		});
+
+		expect(manifest).toBeUndefined();
+		expect(errors.join()).toContain("unsafe path");
+	});
+
+	it("accepts slots declared as string or array", () => {
+		const { manifest } = validateGardenPluginManifest({
+			...validManifest,
+			slots: {
+				"notes.footer": "templates/a.njk",
+				"common.head": ["templates/b.njk", "templates/c.njk"],
+			},
+		});
+
+		expect(manifest).toBeDefined();
+	});
+});
+
+describe("shouldSkipRepoFile", () => {
+	it.each([
+		[".gitignore"],
+		[".github/workflows/ci.yml"],
+		["node_modules/foo/index.js"],
+	])("skips %s", (path) => {
+		expect(shouldSkipRepoFile(path)).toBe(true);
+	});
+
+	it.each([["garden-plugin.json"], ["templates/foo.njk"], ["README.md"]])(
+		"keeps %s",
+		(path) => {
+			expect(shouldSkipRepoFile(path)).toBe(false);
+		},
+	);
+});

--- a/src/gardenPlugins/manifest.ts
+++ b/src/gardenPlugins/manifest.ts
@@ -3,8 +3,8 @@ import { GardenPluginManifest } from "src/models/gardenPlugin";
 /**
  * Pure helpers for the garden plugin installer: GitHub URL parsing and
  * manifest validation. Mirrors the rules enforced by the template's
- * pluginLoader (see docs/PLUGIN_INSTALLER_SPEC.md in oleeskild/digitalgarden)
- * so an invalid plugin is rejected before anything is written.
+ * pluginLoader (oleeskild/digitalgarden, src/helpers/pluginLoader.js) so an
+ * invalid plugin is rejected before anything is written.
  */
 
 export const GARDEN_PLUGIN_MANIFEST_NAME = "garden-plugin.json";

--- a/src/gardenPlugins/manifest.ts
+++ b/src/gardenPlugins/manifest.ts
@@ -1,0 +1,172 @@
+import { GardenPluginManifest } from "src/models/gardenPlugin";
+
+/**
+ * Pure helpers for the garden plugin installer: GitHub URL parsing and
+ * manifest validation. Mirrors the rules enforced by the template's
+ * pluginLoader (see docs/PLUGIN_INSTALLER_SPEC.md in oleeskild/digitalgarden)
+ * so an invalid plugin is rejected before anything is written.
+ */
+
+export const GARDEN_PLUGIN_MANIFEST_NAME = "garden-plugin.json";
+export const MAX_PLUGIN_FILE_SIZE = 2 * 1024 * 1024;
+export const MAX_PLUGIN_TOTAL_SIZE = 10 * 1024 * 1024;
+
+const ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+const REQUIRED_FIELDS = [
+	"id",
+	"name",
+	"version",
+	"description",
+	"author",
+] as const;
+
+/**
+ * Parse a GitHub repo reference in any common shape into owner/name:
+ * `owner/repo`, `https://github.com/owner/repo`, with or without `.git`,
+ * trailing slashes, or a deep link into the repo.
+ */
+export function parseGitHubRepoInput(
+	input: string,
+): { owner: string; repo: string } | undefined {
+	const trimmed = input.trim();
+
+	if (!trimmed) {
+		return undefined;
+	}
+
+	const withoutProtocol = trimmed
+		.replace(/^(https?:\/\/)?(www\.)?github\.com[/:]/i, "")
+		.replace(/^git@github\.com:/i, "");
+
+	// Reject full URLs to other hosts.
+	if (/^[a-z][a-z0-9+.-]*:\/\//i.test(withoutProtocol)) {
+		return undefined;
+	}
+
+	const segments = withoutProtocol.split("/").filter(Boolean);
+
+	if (segments.length < 2) {
+		return undefined;
+	}
+
+	const owner = segments[0];
+	const repo = segments[1].replace(/\.git$/i, "");
+	const namePattern = /^[A-Za-z0-9_.-]+$/;
+
+	if (!namePattern.test(owner) || !namePattern.test(repo) || !repo) {
+		return undefined;
+	}
+
+	return { owner, repo };
+}
+
+/**
+ * A manifest-declared path must stay inside the plugin directory:
+ * relative, `/` separators, no `..`, no leading `/`, no `\`.
+ * A trailing `/` (directory reference, e.g. `assets/`) is allowed.
+ */
+export function isSafePluginPath(path: string): boolean {
+	if (typeof path !== "string" || path.length === 0) {
+		return false;
+	}
+
+	if (path.includes("\\") || path.includes("\0")) {
+		return false;
+	}
+
+	const trimmed = path.endsWith("/") ? path.slice(0, -1) : path;
+
+	if (trimmed.length === 0 || trimmed.startsWith("/")) {
+		return false;
+	}
+
+	return trimmed
+		.split("/")
+		.every(
+			(segment) => segment !== "" && segment !== "." && segment !== "..",
+		);
+}
+
+const asArray = <T>(value: T | T[] | undefined): T[] => {
+	if (value === undefined || value === null) {
+		return [];
+	}
+
+	return Array.isArray(value) ? value : [value];
+};
+
+/**
+ * Validate a parsed garden-plugin.json for installation. Returns the typed
+ * manifest, or a list of human-readable problems.
+ */
+export function validateGardenPluginManifest(
+	parsed: unknown,
+	options: { allowFirstParty?: boolean } = {},
+): { manifest?: GardenPluginManifest; errors: string[] } {
+	const errors: string[] = [];
+
+	if (typeof parsed !== "object" || parsed === null) {
+		return { errors: ["garden-plugin.json is not a JSON object"] };
+	}
+
+	const manifest = parsed as GardenPluginManifest;
+
+	for (const field of REQUIRED_FIELDS) {
+		if (typeof manifest[field] !== "string" || !manifest[field]) {
+			errors.push(`missing required field "${field}"`);
+		}
+	}
+
+	if (typeof manifest.id === "string" && !ID_PATTERN.test(manifest.id)) {
+		errors.push(
+			`invalid id "${manifest.id}" (lowercase letters, digits and dashes only)`,
+		);
+	}
+
+	if (
+		!options.allowFirstParty &&
+		typeof manifest.id === "string" &&
+		manifest.id.startsWith("dg-")
+	) {
+		errors.push(
+			`the "dg-" id prefix is reserved for plugins shipped with the template`,
+		);
+	}
+
+	const declaredPaths = [
+		...asArray(manifest.hooks),
+		...Object.values(manifest.slots ?? {}).flatMap((files) =>
+			asArray(files),
+		),
+		...Object.values(manifest.regions ?? {}),
+		...asArray(manifest.styles),
+		...asArray(manifest.scripts),
+		...asArray(manifest.assets),
+	];
+
+	for (const declared of declaredPaths) {
+		if (!isSafePluginPath(declared)) {
+			errors.push(`unsafe path "${declared}" in manifest`);
+		}
+	}
+
+	if (errors.length > 0) {
+		return { errors };
+	}
+
+	return { manifest, errors };
+}
+
+/**
+ * Repo files that have no runtime purpose and are skipped at install time.
+ */
+export function shouldSkipRepoFile(path: string): boolean {
+	const firstSegment = path.split("/")[0];
+
+	return (
+		firstSegment.startsWith(".git") ||
+		firstSegment === ".github" ||
+		firstSegment === "node_modules"
+	);
+}

--- a/src/gardenPlugins/notices.ts
+++ b/src/gardenPlugins/notices.ts
@@ -1,0 +1,18 @@
+import DigitalGardenSettings from "src/models/settings";
+import { PublishPlatform } from "src/models/PublishPlatform";
+
+/**
+ * Suffix for notices after a change was committed to the garden repo.
+ * Committing triggers a site build (Forestry builds automatically;
+ * self-hosted gardens build via their git-connected host), so tell the
+ * user the change is on its way rather than "on the next build".
+ */
+export function buildTriggeredNotice(
+	settings: Pick<DigitalGardenSettings, "publishPlatform">,
+): string {
+	if (settings.publishPlatform === PublishPlatform.ForestryMd) {
+		return "Forestry is rebuilding your garden — the change will be live when the build finishes.";
+	}
+
+	return "A site build has been triggered — the change will be live when it finishes.";
+}

--- a/src/gardenPlugins/regions.test.ts
+++ b/src/gardenPlugins/regions.test.ts
@@ -1,0 +1,97 @@
+import { getRegionConflicts, getRegionProviders, regionsOf } from "./regions";
+import {
+	GardenPluginManifest,
+	InstalledGardenPlugin,
+} from "src/models/gardenPlugin";
+
+const makeInstalled = (
+	id: string,
+	enabled: boolean,
+	regions?: Record<string, string>,
+): InstalledGardenPlugin => ({
+	manifest: {
+		id,
+		name: id,
+		version: "1.0.0",
+		description: "",
+		author: "",
+		regions,
+	},
+	enabled,
+	isFirstParty: id.startsWith("dg-"),
+});
+
+describe("regionsOf", () => {
+	it("returns declared region names", () => {
+		expect(
+			regionsOf({
+				regions: { navigation: "t.njk" },
+			} as unknown as GardenPluginManifest),
+		).toEqual(["navigation"]);
+
+		expect(regionsOf({} as GardenPluginManifest)).toEqual([]);
+	});
+});
+
+describe("getRegionProviders", () => {
+	it("assigns each region to the first enabled claimant by id", () => {
+		const providers = getRegionProviders([
+			makeInstalled("moc-nav", true, { navigation: "t.njk" }),
+			makeInstalled("dg-filetree", true, { navigation: "t.njk" }),
+		]);
+
+		expect(providers).toEqual({ navigation: "dg-filetree" });
+	});
+
+	it("skips disabled claimants", () => {
+		const providers = getRegionProviders([
+			makeInstalled("dg-filetree", false, { navigation: "t.njk" }),
+			makeInstalled("moc-nav", true, { navigation: "t.njk" }),
+		]);
+
+		expect(providers).toEqual({ navigation: "moc-nav" });
+	});
+
+	it("returns nothing when no plugin claims regions", () => {
+		expect(getRegionProviders([makeInstalled("dg-search", true)])).toEqual(
+			{},
+		);
+	});
+});
+
+describe("getRegionConflicts", () => {
+	const incoming = {
+		id: "moc-nav",
+		name: "MOC",
+		version: "1.0.0",
+		description: "",
+		author: "",
+		regions: { navigation: "t.njk" },
+	} as GardenPluginManifest;
+
+	it("finds enabled plugins claiming the same region", () => {
+		const conflicts = getRegionConflicts(incoming, [
+			makeInstalled("dg-filetree", true, { navigation: "t.njk" }),
+			makeInstalled("dg-search", true),
+		]);
+
+		expect(conflicts.map((c) => c.manifest.id)).toEqual(["dg-filetree"]);
+	});
+
+	it("ignores disabled plugins and the incoming plugin itself", () => {
+		const conflicts = getRegionConflicts(incoming, [
+			makeInstalled("dg-filetree", false, { navigation: "t.njk" }),
+			makeInstalled("moc-nav", true, { navigation: "t.njk" }),
+		]);
+
+		expect(conflicts).toEqual([]);
+	});
+
+	it("returns nothing when the incoming plugin claims no region", () => {
+		expect(
+			getRegionConflicts({ id: "x" } as GardenPluginManifest, [
+				makeInstalled("dg-filetree", true, { navigation: "t.njk" }),
+			]),
+		).toEqual([]);
+	});
+});

--- a/src/gardenPlugins/regions.ts
+++ b/src/gardenPlugins/regions.ts
@@ -1,0 +1,61 @@
+import {
+	GardenPluginManifest,
+	InstalledGardenPlugin,
+} from "src/models/gardenPlugin";
+
+/**
+ * Region resolution, mirroring the garden template's plugin loader: a
+ * region (an exclusive render site like "navigation") is provided by the
+ * first enabled plugin claiming it, in id order. Everything here is pure
+ * so the settings UI and the installer share one source of truth.
+ */
+
+export function regionsOf(manifest: GardenPluginManifest): string[] {
+	return Object.keys(manifest.regions ?? {});
+}
+
+/**
+ * Which plugin provides each region: first enabled claimant by id.
+ */
+export function getRegionProviders(
+	installed: InstalledGardenPlugin[],
+): Record<string, string> {
+	const providers: Record<string, string> = {};
+
+	const enabled = [...installed]
+		.filter((plugin) => plugin.enabled)
+		.sort((a, b) => a.manifest.id.localeCompare(b.manifest.id));
+
+	for (const plugin of enabled) {
+		for (const region of regionsOf(plugin.manifest)) {
+			providers[region] ??= plugin.manifest.id;
+		}
+	}
+
+	return providers;
+}
+
+/**
+ * Enabled plugins (other than the incoming one) that claim any of the
+ * same regions as the incoming manifest — the plugins a user probably
+ * wants disabled so the incoming plugin actually renders.
+ */
+export function getRegionConflicts(
+	incoming: GardenPluginManifest,
+	installed: InstalledGardenPlugin[],
+): InstalledGardenPlugin[] {
+	const incomingRegions = regionsOf(incoming);
+
+	if (incomingRegions.length === 0) {
+		return [];
+	}
+
+	return installed.filter(
+		(plugin) =>
+			plugin.enabled &&
+			plugin.manifest.id !== incoming.id &&
+			regionsOf(plugin.manifest).some((region) =>
+				incomingRegions.includes(region),
+			),
+	);
+}

--- a/src/models/gardenPlugin.ts
+++ b/src/models/gardenPlugin.ts
@@ -1,7 +1,7 @@
 /**
  * Types for the garden plugin system. The formats are defined by the garden
- * template repo (oleeskild/digitalgarden): see docs/PLUGINS.md (manifest)
- * and docs/PLUGIN_INSTALLER_SPEC.md (registry, installer contract) there.
+ * template repo (oleeskild/digitalgarden) — the template's pluginLoader is
+ * the authority on manifest and registry semantics.
  */
 
 /** One user-facing setting declared by a plugin manifest. */

--- a/src/models/gardenPlugin.ts
+++ b/src/models/gardenPlugin.ts
@@ -1,0 +1,74 @@
+/**
+ * Types for the garden plugin system. The formats are defined by the garden
+ * template repo (oleeskild/digitalgarden): see docs/PLUGINS.md (manifest)
+ * and docs/PLUGIN_INSTALLER_SPEC.md (registry, installer contract) there.
+ */
+
+/** One user-facing setting declared by a plugin manifest. */
+export interface GardenPluginSettingEntry {
+	key: string;
+	name: string;
+	description?: string;
+	type: "text" | "boolean" | "number" | "select";
+	default?: string | number | boolean;
+	options?: string[];
+	/** Env var consulted by the template when no registry value is stored. */
+	env?: string;
+}
+
+/** The garden-plugin.json manifest at the root of a plugin. */
+export interface GardenPluginManifest {
+	id: string;
+	name: string;
+	version: string;
+	description: string;
+	author: string;
+	minTemplateVersion?: string;
+	hooks?: string;
+	slots?: Record<string, string | string[]>;
+	/** Exclusive render sites (e.g. "navigation") — one provider wins. */
+	regions?: Record<string, string>;
+	styles?: string[];
+	scripts?: string[];
+	assets?: string[];
+	settings?: GardenPluginSettingEntry[];
+	noteSettings?: string[];
+}
+
+/** Per-plugin state stored in src/plugins/plugins.json in the garden repo. */
+export interface GardenPluginRegistryEntry {
+	repo?: string;
+	installedVersion?: string;
+	installedRef?: string;
+	installedAt?: string;
+	enabled?: boolean;
+	settings?: Record<string, string | number | boolean>;
+	/** Exact repo paths written at install time, used for clean uninstall. */
+	files?: string[];
+}
+
+/** The user-owned state file src/plugins/plugins.json. */
+export interface GardenPluginRegistry {
+	version: number;
+	plugins: Record<string, GardenPluginRegistryEntry>;
+}
+
+/** An installed plugin: its manifest merged with its registry state. */
+export interface InstalledGardenPlugin {
+	manifest: GardenPluginManifest;
+	registryEntry?: GardenPluginRegistryEntry;
+	enabled: boolean;
+	/** Shipped with the template (dg-*), managed by template updates. */
+	isFirstParty: boolean;
+}
+
+/** One entry in the community registry's community-plugins.json. */
+export interface CommunityGardenPlugin {
+	id: string;
+	name: string;
+	author: string;
+	description: string;
+	/** GitHub repo as owner/name. */
+	repo: string;
+	screenshot?: string;
+}

--- a/src/publisher/paths.ts
+++ b/src/publisher/paths.ts
@@ -8,6 +8,7 @@ import { PublishPlatform } from "../models/PublishPlatform";
  */
 export const NOTE_PATH_BASE = "src/site/notes/";
 export const IMAGE_PATH_BASE = "src/site/img/user/";
+export const GARDEN_PLUGINS_PATH_BASE = "src/plugins/";
 
 /** Only the fields the path builders actually depend on. */
 type ContentBaseSettings = Pick<
@@ -97,4 +98,16 @@ export function sitePath(settings: ContentBaseSettings, sub: string): string {
 /** Repo path to the garden `.env` file, e.g. `.env` or `Web/.env`. */
 export function envPath(settings: ContentBaseSettings): string {
 	return `${contentBaseDir(settings)}.env`;
+}
+
+/** Repo path to the garden plugins directory, e.g. `src/plugins/` or `Web/src/plugins/`. */
+export function gardenPluginsPathBase(settings: ContentBaseSettings): string {
+	return `${contentBaseDir(settings)}${GARDEN_PLUGINS_PATH_BASE}`;
+}
+
+/** Repo path to the user-owned garden plugin registry (state) file. */
+export function gardenPluginsRegistryPath(
+	settings: ContentBaseSettings,
+): string {
+	return `${gardenPluginsPathBase(settings)}plugins.json`;
 }

--- a/src/repositoryConnection/PublishPlatformConnectionFactory.ts
+++ b/src/repositoryConnection/PublishPlatformConnectionFactory.ts
@@ -11,10 +11,18 @@ const DEFAULT_FORESTRY_BASE_URL = "https://api.forestry.md/app";
 
 export default class PublishPlatformConnectionFactory {
 	static createBaseGardenConnection(): IPublishPlatformConnection {
+		return this.createGitHubConnection("oleeskild", "digitalgarden");
+	}
+
+	/** Unauthenticated connection to an arbitrary public GitHub repo. */
+	static createGitHubConnection(
+		userName: string,
+		pageName: string,
+	): IPublishPlatformConnection {
 		return {
 			octoKit: new Octokit({ log: oktokitLogger }),
-			userName: "oleeskild",
-			pageName: "digitalgarden",
+			userName,
+			pageName,
 		};
 	}
 	static async createPublishPlatformConnection(

--- a/src/repositoryConnection/RepositoryConnection.ts
+++ b/src/repositoryConnection/RepositoryConnection.ts
@@ -84,12 +84,18 @@ export class RepositoryConnection {
 		);
 
 		try {
+			// The cacheBust param defeats Electron's HTTP cache (GitHub serves
+			// max-age=60): a stale response here means a stale file sha, which
+			// makes the next updateFile fail as an edit conflict.
 			const response = await this.octokit.request(
-				"GET /repos/{owner}/{repo}/contents/{path}",
+				`GET /repos/{owner}/{repo}/contents/{path}?cacheBust=${Date.now()}`,
 				{
 					...this.getBasePayload(),
 					path,
 					ref: branch,
+					headers: {
+						"If-None-Match": "",
+					},
 				},
 			);
 
@@ -104,6 +110,28 @@ export class RepositoryConnection {
 			throw new Error(
 				`Could not get file ${path} from repository ${this.getRepositoryName()}`,
 			);
+		}
+	}
+
+	/**
+	 * Get a blob's base64 content by sha (from a tree listing). Unlike the
+	 * contents API, this works for files larger than 1 MB.
+	 */
+	async getBlob(fileSha: string): Promise<string | undefined> {
+		try {
+			const response = await this.octokit.request(
+				"GET /repos/{owner}/{repo}/git/blobs/{file_sha}",
+				{
+					...this.getBasePayload(),
+					file_sha: fileSha,
+				},
+			);
+
+			if (response.status === 200) {
+				return response.data.content;
+			}
+		} catch (error) {
+			logger.error(error);
 		}
 	}
 
@@ -434,6 +462,98 @@ export class RepositoryConnection {
 				message: commitMessage,
 				tree: newTree.data.sha,
 				parents: [latestCommitSha],
+			},
+		);
+
+		const defaultBranch = (await repoDataPromise).data.default_branch;
+
+		await this.octokit.request(
+			"PATCH /repos/{owner}/{repo}/git/refs/heads/{branch}",
+			{
+				...this.getBasePayload(),
+				branch: defaultBranch,
+				sha: newCommit.data.sha,
+			},
+		);
+	}
+
+	/**
+	 * Commit a set of raw file additions/updates and deletions as one atomic
+	 * commit on the default branch (blobs → tree → commit → ref, the same
+	 * flow as {@link updateFiles}). Used by the garden plugin installer so an
+	 * install, update, or uninstall is always a single commit. Paths are full
+	 * repo paths; addition content is base64. Throws on failure — callers
+	 * surface the error to the user.
+	 */
+	async commitChanges({
+		additions = [],
+		deletions = [],
+		message,
+	}: {
+		additions?: { path: string; content: string }[];
+		deletions?: string[];
+		message: string;
+	}) {
+		if (additions.length === 0 && deletions.length === 0) {
+			return;
+		}
+
+		const latestCommit = await this.getLatestCommit();
+
+		if (!latestCommit) {
+			throw new Error("Could not get latest commit");
+		}
+
+		const repoDataPromise = this.octokit.request(
+			"GET /repos/{owner}/{repo}",
+			{
+				...this.getBasePayload(),
+			},
+		);
+
+		const additionEntries = await Promise.all(
+			additions.map(async (file) => {
+				const blob = await this.octokit.request(
+					"POST /repos/{owner}/{repo}/git/blobs",
+					{
+						...this.getBasePayload(),
+						content: file.content,
+						encoding: "base64",
+					},
+				);
+
+				return {
+					path: file.path,
+					mode: "100644" as const,
+					type: "blob" as const,
+					sha: blob.data.sha,
+				};
+			}),
+		);
+
+		const deletionEntries = deletions.map((path) => ({
+			path,
+			mode: "100644" as const,
+			type: "blob" as const,
+			sha: null,
+		}));
+
+		const newTree = await this.octokit.request(
+			"POST /repos/{owner}/{repo}/git/trees",
+			{
+				...this.getBasePayload(),
+				base_tree: latestCommit.commit.tree.sha,
+				tree: [...additionEntries, ...deletionEntries],
+			},
+		);
+
+		const newCommit = await this.octokit.request(
+			"POST /repos/{owner}/{repo}/git/commits",
+			{
+				...this.getBasePayload(),
+				message,
+				tree: newTree.data.sha,
+				parents: [latestCommit.sha],
 			},
 		);
 

--- a/src/test/paths.test.ts
+++ b/src/test/paths.test.ts
@@ -9,6 +9,8 @@ import {
 	imagePathBase,
 	sitePath,
 	envPath,
+	gardenPluginsPathBase,
+	gardenPluginsRegistryPath,
 } from "../publisher/paths";
 
 const withBase = (contentBase?: string) =>
@@ -89,6 +91,26 @@ describe("paths", () => {
 			expect(notePathBase(undefinedSettings)).toBe("src/site/notes/");
 			expect(imagePathBase(undefinedSettings)).toBe("src/site/img/user/");
 			expect(envPath(undefinedSettings)).toBe(".env");
+		});
+	});
+
+	describe("garden plugin paths", () => {
+		it("builds the plugins base and registry path without a base dir", () => {
+			expect(gardenPluginsPathBase(withBase(""))).toBe("src/plugins/");
+
+			expect(gardenPluginsRegistryPath(withBase(""))).toBe(
+				"src/plugins/plugins.json",
+			);
+		});
+
+		it("applies the content base dir", () => {
+			expect(gardenPluginsPathBase(withBase("Web"))).toBe(
+				"Web/src/plugins/",
+			);
+
+			expect(gardenPluginsRegistryPath(withBase("Web"))).toBe(
+				"Web/src/plugins/plugins.json",
+			);
 		});
 	});
 

--- a/src/views/GardenPluginSettings/GardenPluginsModal.ts
+++ b/src/views/GardenPluginSettings/GardenPluginsModal.ts
@@ -1,0 +1,48 @@
+import { App, Modal } from "obsidian";
+import { mount, unmount } from "svelte";
+import GardenPluginsView from "./GardenPluginsView.svelte";
+import { GardenPluginManager } from "../../gardenPlugins/GardenPluginManager";
+import DigitalGardenSettings from "../../models/settings";
+
+export class GardenPluginsModal {
+	modal: Modal;
+	private view: ReturnType<typeof mount> | undefined;
+
+	constructor(
+		app: App,
+		private manager: GardenPluginManager,
+		private settings: DigitalGardenSettings,
+		private saveSettings: () => Promise<void>,
+		private applyNoteSettingsToSite: () => Promise<void>,
+	) {
+		this.modal = new Modal(app);
+		this.modal.titleEl.innerText = "Garden Plugins";
+	}
+
+	open = () => {
+		this.modal.onClose = () => {
+			if (this.view) {
+				unmount(this.view);
+				this.view = undefined;
+			}
+		};
+
+		this.modal.onOpen = () => {
+			this.modal.contentEl.empty();
+			this.modal.contentEl.addClass("dg-garden-plugins-modal");
+			this.modal.modalEl.style.width = "min(760px, 92vw)";
+
+			this.view = mount(GardenPluginsView, {
+				target: this.modal.contentEl,
+				props: {
+					manager: this.manager,
+					settings: this.settings,
+					saveSettings: this.saveSettings,
+					applyNoteSettingsToSite: this.applyNoteSettingsToSite,
+				},
+			});
+		};
+
+		this.modal.open();
+	};
+}

--- a/src/views/GardenPluginSettings/GardenPluginsView.svelte
+++ b/src/views/GardenPluginSettings/GardenPluginsView.svelte
@@ -1,0 +1,1052 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { Notice } from "obsidian";
+	import type {
+		GardenPluginManager,
+		RemoteGardenPlugin,
+	} from "../../gardenPlugins/GardenPluginManager";
+	import type {
+		CommunityGardenPlugin,
+		GardenPluginSettingEntry,
+		InstalledGardenPlugin,
+	} from "../../models/gardenPlugin";
+	import type DigitalGardenSettings from "../../models/settings";
+	import {
+		getRegionConflicts,
+		getRegionProviders,
+		regionsOf,
+	} from "../../gardenPlugins/regions";
+	import { buildTriggeredNotice } from "../../gardenPlugins/notices";
+
+	export let manager: GardenPluginManager;
+	export let settings: DigitalGardenSettings;
+	export let saveSettings: () => Promise<void>;
+	export let applyNoteSettingsToSite: () => Promise<void>;
+
+	let loading = true;
+	let loadError: string | null = null;
+	let installed: InstalledGardenPlugin[] = [];
+	let community: CommunityGardenPlugin[] = [];
+	let communityFilter = "";
+	let communityLoading = true;
+	let busy = false;
+
+	let installInput = "";
+	let inspecting = false;
+	let installError: string | null = null;
+	let pendingInstall: RemoteGardenPlugin | null = null;
+	let pendingIsUpdate = false;
+
+	let expandedSettingsId: string | null = null;
+	let settingsDraft: Record<string, string | number | boolean> = {};
+	let activeTab: "installed" | "browse" = "installed";
+
+	onMount(async () => {
+		await refresh();
+		community = await manager.fetchCommunityPlugins();
+		communityLoading = false;
+	});
+
+	async function refresh() {
+		loading = true;
+		loadError = null;
+
+		try {
+			installed = await manager.listInstalled();
+		} catch (error) {
+			loadError =
+				error instanceof Error
+					? error.message
+					: "Could not read plugins from your garden repository";
+		}
+
+		loading = false;
+	}
+
+	function installedIds(): Set<string> {
+		return new Set(installed.map((plugin) => plugin.manifest.id));
+	}
+
+	async function toggleEnabled(plugin: InstalledGardenPlugin) {
+		busy = true;
+
+		try {
+			await manager.setEnabled(plugin.manifest.id, !plugin.enabled);
+
+			new Notice(
+				`${plugin.manifest.name} ${
+					plugin.enabled ? "disabled" : "enabled"
+				}. ${buildTriggeredNotice(settings)}`,
+			);
+			await refresh();
+		} catch (error) {
+			new Notice(
+				`Could not ${plugin.enabled ? "disable" : "enable"} ${
+					plugin.manifest.name
+				}: ${error instanceof Error ? error.message : "unknown error"}`,
+			);
+		}
+
+		busy = false;
+	}
+
+	function openSettings(plugin: InstalledGardenPlugin) {
+		if (expandedSettingsId === plugin.manifest.id) {
+			expandedSettingsId = null;
+
+			return;
+		}
+
+		expandedSettingsId = plugin.manifest.id;
+		settingsDraft = {};
+
+		for (const entry of plugin.manifest.settings ?? []) {
+			const stored = plugin.registryEntry?.settings?.[entry.key];
+			settingsDraft[entry.key] = stored ?? entry.default ?? "";
+		}
+	}
+
+	function coerce(entry: GardenPluginSettingEntry, value: string) {
+		if (entry.type === "number") {
+			return Number(value);
+		}
+
+		return value;
+	}
+
+	async function saveDraft(plugin: InstalledGardenPlugin) {
+		busy = true;
+
+		try {
+			await manager.savePluginSettings(plugin.manifest.id, settingsDraft);
+
+			new Notice(
+				`Saved settings for ${
+					plugin.manifest.name
+				}. ${buildTriggeredNotice(settings)}`,
+			);
+			expandedSettingsId = null;
+			await refresh();
+		} catch {
+			new Notice(`Could not save settings for ${plugin.manifest.name}`);
+		}
+
+		busy = false;
+	}
+
+	function noteSettingKeysFor(plugin: InstalledGardenPlugin): string[] {
+		return (plugin.manifest.noteSettings ?? []).filter(
+			(key) => key in settings.defaultNoteSettings,
+		);
+	}
+
+	async function toggleNoteSetting(key: string) {
+		const noteSettings = settings.defaultNoteSettings as Record<
+			string,
+			boolean
+		>;
+		noteSettings[key] = !noteSettings[key];
+		await saveSettings();
+		await applyNoteSettingsToSite();
+		installed = installed;
+	}
+
+	async function inspect(repoInput: string, isUpdate = false) {
+		inspecting = true;
+		installError = null;
+		pendingInstall = null;
+		disableConflicts = true;
+
+		try {
+			const remote = await manager.inspectRemotePlugin(repoInput);
+
+			if (!isUpdate && installedIds().has(remote.manifest.id)) {
+				pendingIsUpdate = true;
+			} else {
+				pendingIsUpdate = isUpdate;
+			}
+
+			pendingInstall = remote;
+		} catch (error) {
+			installError =
+				error instanceof Error ? error.message : "Unknown error";
+		}
+
+		inspecting = false;
+	}
+
+	async function confirmInstall() {
+		if (!pendingInstall) {
+			return;
+		}
+
+		busy = true;
+		const remote = pendingInstall;
+
+		const existingEntry = installed.find(
+			(plugin) => plugin.manifest.id === remote.manifest.id,
+		)?.registryEntry;
+
+		const disableIds = disableConflicts
+			? pendingConflicts.map((conflict) => conflict.manifest.id)
+			: [];
+
+		try {
+			await manager.install(remote, existingEntry, disableIds);
+
+			new Notice(
+				`${pendingIsUpdate ? "Updated" : "Installed"} ${
+					remote.manifest.name
+				} ${remote.manifest.version}. ${buildTriggeredNotice(
+					settings,
+				)}`,
+			);
+			pendingInstall = null;
+			installInput = "";
+			await refresh();
+		} catch (error) {
+			installError =
+				error instanceof Error ? error.message : "Install failed";
+		}
+
+		busy = false;
+	}
+
+	async function updatePlugin(plugin: InstalledGardenPlugin) {
+		const repo = plugin.registryEntry?.repo;
+
+		if (!repo) {
+			installError = `${plugin.manifest.name} has no recorded source repository. Reinstall it from a GitHub URL to enable updates.`;
+
+			return;
+		}
+
+		// The confirmation panel lives in the browse tab
+		activeTab = "browse";
+		await inspect(repo, true);
+	}
+
+	let confirmUninstallId: string | null = null;
+
+	async function uninstall(plugin: InstalledGardenPlugin) {
+		busy = true;
+
+		try {
+			await manager.uninstall(plugin);
+
+			new Notice(
+				`Uninstalled ${plugin.manifest.name}. ${buildTriggeredNotice(
+					settings,
+				)}`,
+			);
+			confirmUninstallId = null;
+			await refresh();
+		} catch {
+			new Notice(`Could not uninstall ${plugin.manifest.name}`);
+		}
+
+		busy = false;
+	}
+
+	$: regionProviders = getRegionProviders(installed);
+
+	$: pendingConflicts = pendingInstall
+		? getRegionConflicts(pendingInstall.manifest, installed)
+		: [];
+
+	let disableConflicts = true;
+
+	function pluginName(id: string): string {
+		return (
+			installed.find((plugin) => plugin.manifest.id === id)?.manifest
+				.name ?? id
+		);
+	}
+
+	function providedRegions(plugin: InstalledGardenPlugin): string[] {
+		return regionsOf(plugin.manifest).filter(
+			(region) => regionProviders[region] === plugin.manifest.id,
+		);
+	}
+
+	function blockedRegions(
+		plugin: InstalledGardenPlugin,
+	): { region: string; providerId: string }[] {
+		if (!plugin.enabled) {
+			return [];
+		}
+
+		return regionsOf(plugin.manifest)
+			.filter(
+				(region) =>
+					regionProviders[region] &&
+					regionProviders[region] !== plugin.manifest.id,
+			)
+			.map((region) => ({ region, providerId: regionProviders[region] }));
+	}
+
+	$: filteredCommunity = community.filter(
+		(entry) =>
+			!communityFilter ||
+			entry.name.toLowerCase().includes(communityFilter.toLowerCase()) ||
+			entry.description
+				.toLowerCase()
+				.includes(communityFilter.toLowerCase()),
+	);
+</script>
+
+<div class="dg-plugins">
+	<div class="dg-plugin-tabs" role="tablist">
+		<button
+			role="tab"
+			aria-selected={activeTab === "installed"}
+			class:is-active={activeTab === "installed"}
+			on:click={() => (activeTab = "installed")}
+		>
+			Installed{#if !loading}&nbsp;({installed.length}){/if}
+		</button>
+
+		<button
+			role="tab"
+			aria-selected={activeTab === "browse"}
+			class:is-active={activeTab === "browse"}
+			on:click={() => (activeTab = "browse")}
+		>
+			Browse &amp; install{#if community.length > 0}&nbsp;({community.length}){/if}
+		</button>
+	</div>
+
+	{#if activeTab === "installed"}
+		<p class="dg-plugins-intro">
+			Plugins extend your garden with new features. They are stored in
+			your garden repository under <code>src/plugins/</code> — this list is
+			read directly from it.
+		</p>
+
+		{#if loading}
+			<div
+				class="dg-plugins-loading"
+				role="status"
+				aria-label="Loading plugins from your garden repository"
+			>
+				{#each [0, 1, 2] as i (i)}
+					<div
+						class="dg-skeleton-row"
+						style={`--dg-skeleton-delay: ${i * 0.15}s`}
+					>
+						<div class="dg-skeleton-info">
+							<span class="dg-skeleton dg-skeleton-title"></span>
+							<span class="dg-skeleton dg-skeleton-text"></span>
+						</div>
+						<span class="dg-skeleton dg-skeleton-pill"></span>
+					</div>
+				{/each}
+
+				<p class="dg-plugins-loading-hint">
+					<span class="dg-spinner" aria-hidden="true"></span>
+					Reading plugins from your garden repository…
+				</p>
+			</div>
+		{:else if loadError}
+			<p class="dg-plugins-error">{loadError}</p>
+		{:else}
+			{#if installed.length === 0}
+				<p>
+					No plugins found. If your garden predates the plugin system,
+					update your site template first.
+				</p>
+			{/if}
+
+			{#each installed as plugin (plugin.manifest.id)}
+				<div class="dg-plugin-row" class:is-disabled={!plugin.enabled}>
+					<div class="dg-plugin-row-main">
+						<div class="dg-plugin-row-info">
+							<span class="dg-plugin-name">
+								{plugin.manifest.name}
+								<span class="dg-plugin-version"
+									>v{plugin.manifest.version}</span
+								>
+
+								{#if plugin.isFirstParty}
+									<span class="dg-plugin-badge"
+										>Core plugin</span
+									>
+								{/if}
+
+								{#each providedRegions(plugin) as region (region)}
+									<span class="dg-plugin-badge is-region"
+										>Provides {region}</span
+									>
+								{/each}
+							</span>
+
+							<span class="dg-plugin-description"
+								>{plugin.manifest.description}</span
+							>
+
+							<span class="dg-plugin-author"
+								>by {plugin.manifest.author}</span
+							>
+
+							{#each blockedRegions(plugin) as blocked (blocked.region)}
+								<span class="dg-plugin-region-notice">
+									{blocked.region.charAt(0).toUpperCase() +
+										blocked.region.slice(1)} is currently provided
+									by
+									<strong
+										>{pluginName(
+											blocked.providerId,
+										)}</strong
+									>
+									— disable it to activate this plugin.
+								</span>
+							{/each}
+						</div>
+
+						<div class="dg-plugin-row-actions">
+							{#if (plugin.manifest.settings ?? []).length > 0 || noteSettingKeysFor(plugin).length > 0}
+								<button
+									disabled={busy}
+									on:click={() => openSettings(plugin)}
+									>Settings</button
+								>
+							{/if}
+
+							{#if !plugin.isFirstParty}
+								<button
+									disabled={busy}
+									on:click={() => updatePlugin(plugin)}
+									>Update</button
+								>
+
+								{#if confirmUninstallId === plugin.manifest.id}
+									<button
+										class="mod-warning"
+										disabled={busy}
+										on:click={() => uninstall(plugin)}
+										>Confirm removal</button
+									>
+								{:else}
+									<button
+										disabled={busy}
+										on:click={() =>
+											(confirmUninstallId =
+												plugin.manifest.id)}
+										>Uninstall</button
+									>
+								{/if}
+							{/if}
+
+							<label class="dg-plugin-toggle">
+								<input
+									type="checkbox"
+									checked={plugin.enabled}
+									disabled={busy}
+									on:change={() => toggleEnabled(plugin)}
+								/>
+								{plugin.enabled ? "Enabled" : "Disabled"}
+							</label>
+						</div>
+					</div>
+
+					{#if expandedSettingsId === plugin.manifest.id}
+						<div class="dg-plugin-settings">
+							{#each noteSettingKeysFor(plugin) as key (key)}
+								<label class="dg-plugin-setting">
+									<span>
+										<span class="dg-plugin-setting-name"
+											>Enabled by default on notes</span
+										>
+										<span class="dg-plugin-setting-desc">
+											Override per note with
+											<code
+												>{key.replace(
+													/[A-Z]/g,
+													(c) =>
+														`-${c.toLowerCase()}`,
+												)}</code
+											> in frontmatter.
+										</span>
+									</span>
+
+									<input
+										type="checkbox"
+										checked={settings.defaultNoteSettings[
+											key
+										]}
+										disabled={busy}
+										on:change={() => toggleNoteSetting(key)}
+									/>
+								</label>
+							{/each}
+
+							{#each plugin.manifest.settings ?? [] as entry (entry.key)}
+								<label class="dg-plugin-setting">
+									<span>
+										<span class="dg-plugin-setting-name"
+											>{entry.name}</span
+										>
+
+										{#if entry.description}
+											<span class="dg-plugin-setting-desc"
+												>{entry.description}</span
+											>
+										{/if}
+									</span>
+
+									{#if entry.type === "boolean"}
+										<input
+											type="checkbox"
+											checked={Boolean(
+												settingsDraft[entry.key],
+											)}
+											on:change={(event) =>
+												(settingsDraft[entry.key] =
+													event.currentTarget.checked)}
+										/>
+									{:else if entry.type === "select"}
+										<select
+											value={String(
+												settingsDraft[entry.key] ?? "",
+											)}
+											on:change={(event) =>
+												(settingsDraft[entry.key] =
+													event.currentTarget.value)}
+										>
+											{#each entry.options ?? [] as option (option)}
+												<option value={option}
+													>{option}</option
+												>
+											{/each}
+										</select>
+									{:else}
+										<input
+											type={entry.type === "number"
+												? "number"
+												: "text"}
+											value={String(
+												settingsDraft[entry.key] ?? "",
+											)}
+											on:input={(event) =>
+												(settingsDraft[entry.key] =
+													coerce(
+														entry,
+														event.currentTarget
+															.value,
+													))}
+										/>
+									{/if}
+								</label>
+							{/each}
+
+							{#if (plugin.manifest.settings ?? []).length > 0}
+								<button
+									class="mod-cta"
+									disabled={busy}
+									on:click={() => saveDraft(plugin)}
+									>Save plugin settings</button
+								>
+							{/if}
+						</div>
+					{/if}
+				</div>
+			{/each}
+		{/if}
+	{:else}
+		<h3>Install from GitHub</h3>
+
+		<p class="dg-plugins-intro">
+			Paste the URL of a plugin repository, e.g.
+			<code>https://github.com/user/garden-plugin-example</code>.
+		</p>
+
+		<div class="dg-plugin-install-row">
+			<input
+				type="text"
+				placeholder="https://github.com/user/repo"
+				bind:value={installInput}
+				disabled={inspecting || busy}
+			/>
+
+			<button
+				class="mod-cta"
+				disabled={inspecting || busy || !installInput.trim()}
+				on:click={() => inspect(installInput)}
+				>{inspecting ? "Checking…" : "Install"}</button
+			>
+		</div>
+
+		{#if installError}
+			<p class="dg-plugins-error">{installError}</p>
+		{/if}
+
+		{#if pendingInstall}
+			<div class="dg-plugin-confirm">
+				<p class="dg-plugin-confirm-title">
+					{pendingIsUpdate ? "Update" : "Install"}
+					<strong>{pendingInstall.manifest.name}</strong>
+					v{pendingInstall.manifest.version} by {pendingInstall
+						.manifest.author}?
+				</p>
+
+				<p>{pendingInstall.manifest.description}</p>
+
+				<p class="dg-plugin-confirm-warning">
+					⚠️ Plugins run their own code in your site's build and in
+					your visitors' browsers. Only install plugins from authors
+					you trust — review the code at
+					<a
+						href={`https://github.com/${pendingInstall.owner}/${pendingInstall.repo}`}
+						>{pendingInstall.owner}/{pendingInstall.repo}</a
+					>
+					({pendingInstall.files.length} files, ref
+					<code>{pendingInstall.ref}</code>).
+				</p>
+
+				{#if pendingConflicts.length > 0}
+					<label class="dg-plugin-conflict-choice">
+						<input
+							type="checkbox"
+							bind:checked={disableConflicts}
+						/>
+						<span>
+							{pendingInstall.manifest.name} replaces
+							<strong
+								>{pendingConflicts
+									.map((c) => c.manifest.name)
+									.join(", ")}</strong
+							>
+							({regionsOf(pendingInstall.manifest).join(", ")}).
+							Disable {pendingConflicts.length === 1
+								? "it"
+								: "them"} so {pendingInstall.manifest.name} takes
+							over right away.
+						</span>
+					</label>
+				{/if}
+
+				<div class="dg-plugin-confirm-actions">
+					<button
+						class="mod-cta"
+						disabled={busy}
+						on:click={confirmInstall}
+						>{busy
+							? "Working…"
+							: pendingIsUpdate
+							? "Update plugin"
+							: "Install plugin"}</button
+					>
+
+					<button
+						disabled={busy}
+						on:click={() => (pendingInstall = null)}>Cancel</button
+					>
+				</div>
+			</div>
+		{/if}
+
+		<h3>Browse community plugins</h3>
+
+		{#if communityLoading}
+			<div
+				class="dg-plugin-grid"
+				role="status"
+				aria-label="Loading community plugins"
+			>
+				{#each [0, 1, 2] as i (i)}
+					<div
+						class="dg-skeleton-card"
+						style={`--dg-skeleton-delay: ${i * 0.15}s`}
+					>
+						<span class="dg-skeleton dg-skeleton-title"></span>
+						<span class="dg-skeleton dg-skeleton-text"></span>
+						<span class="dg-skeleton dg-skeleton-text short"></span>
+					</div>
+				{/each}
+			</div>
+		{:else if community.length === 0}
+			<p>
+				The community plugin directory is not available right now. You
+				can still install any plugin from its GitHub URL above.
+			</p>
+		{:else}
+			<input
+				class="dg-plugin-search"
+				type="text"
+				placeholder="Search community plugins…"
+				bind:value={communityFilter}
+			/>
+
+			<div class="dg-plugin-grid">
+				{#each filteredCommunity as entry (entry.id)}
+					<div class="dg-plugin-card">
+						{#if entry.screenshot}
+							<img
+								class="dg-plugin-card-image"
+								loading="lazy"
+								alt={entry.name}
+								src={`https://raw.githubusercontent.com/${entry.repo}/HEAD/${entry.screenshot}`}
+							/>
+						{/if}
+
+						<div class="dg-plugin-card-body">
+							<span class="dg-plugin-name">{entry.name}</span>
+
+							<span class="dg-plugin-description"
+								>{entry.description}</span
+							>
+
+							<span class="dg-plugin-author"
+								>by {entry.author}</span
+							>
+
+							{#if installedIds().has(entry.id)}
+								<button disabled>Installed</button>
+							{:else}
+								<button
+									class="mod-cta"
+									disabled={inspecting || busy}
+									on:click={() => inspect(entry.repo)}
+									>Install</button
+								>
+							{/if}
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.dg-plugins {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.dg-plugins h3 {
+		margin: 16px 0 4px 0;
+	}
+
+	.dg-plugin-tabs {
+		display: flex;
+		gap: 4px;
+		border-bottom: 1px solid var(--background-modifier-border);
+		margin-bottom: 4px;
+	}
+
+	.dg-plugin-tabs button {
+		background: none;
+		border: none;
+		border-bottom: 2px solid transparent;
+		border-radius: 0;
+		padding: 8px 14px;
+		font-size: 0.95em;
+		color: var(--text-muted);
+		cursor: pointer;
+		box-shadow: none;
+	}
+
+	.dg-plugin-tabs button:hover {
+		color: var(--text-normal);
+	}
+
+	.dg-plugin-tabs button.is-active {
+		color: var(--text-normal);
+		font-weight: 600;
+		border-bottom-color: var(--interactive-accent);
+	}
+
+	.dg-plugins-intro {
+		color: var(--text-muted);
+		margin: 0;
+	}
+
+	.dg-plugins-error {
+		color: var(--text-error);
+	}
+
+	.dg-plugins-loading {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.dg-skeleton-row {
+		border: 1px solid var(--background-modifier-border);
+		border-radius: 8px;
+		padding: 10px 12px;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 12px;
+	}
+
+	.dg-skeleton-info {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		flex: 1;
+	}
+
+	.dg-skeleton-card {
+		border: 1px solid var(--background-modifier-border);
+		border-radius: 8px;
+		padding: 12px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.dg-skeleton {
+		display: block;
+		border-radius: 4px;
+		background: var(--background-modifier-hover, rgba(128, 128, 128, 0.15));
+		animation: dg-skeleton-pulse 1.4s ease-in-out infinite;
+		animation-delay: var(--dg-skeleton-delay, 0s);
+	}
+
+	.dg-skeleton-title {
+		height: 0.9rem;
+		width: 40%;
+	}
+
+	.dg-skeleton-text {
+		height: 0.7rem;
+		width: 75%;
+	}
+
+	.dg-skeleton-text.short {
+		width: 45%;
+	}
+
+	.dg-skeleton-pill {
+		height: 1.4rem;
+		width: 5.5rem;
+		border-radius: 999px;
+	}
+
+	.dg-plugins-loading-hint {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		color: var(--text-muted);
+		font-size: 0.85em;
+		margin: 4px 0 0;
+	}
+
+	.dg-spinner {
+		width: 12px;
+		height: 12px;
+		border: 2px solid currentColor;
+		border-top-color: transparent;
+		border-radius: 50%;
+		animation: dg-spin 0.7s linear infinite;
+		flex-shrink: 0;
+	}
+
+	@keyframes dg-skeleton-pulse {
+		0%,
+		100% {
+			opacity: 0.45;
+		}
+		50% {
+			opacity: 1;
+		}
+	}
+
+	@keyframes dg-spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.dg-skeleton {
+			animation: none;
+			opacity: 0.6;
+		}
+
+		.dg-spinner {
+			animation-duration: 2.5s;
+		}
+	}
+
+	.dg-plugin-row {
+		border: 1px solid var(--background-modifier-border);
+		border-radius: 8px;
+		padding: 10px 12px;
+	}
+
+	.dg-plugin-row.is-disabled {
+		opacity: 0.6;
+	}
+
+	.dg-plugin-row-main {
+		display: flex;
+		justify-content: space-between;
+		gap: 12px;
+		align-items: center;
+		flex-wrap: wrap;
+	}
+
+	.dg-plugin-row-info {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		min-width: 200px;
+		flex: 1;
+	}
+
+	.dg-plugin-name {
+		font-weight: 600;
+	}
+
+	.dg-plugin-version,
+	.dg-plugin-author {
+		color: var(--text-muted);
+		font-size: 0.85em;
+		font-weight: 400;
+	}
+
+	.dg-plugin-badge {
+		background: var(--background-modifier-border);
+		border-radius: 4px;
+		font-size: 0.75em;
+		font-weight: 500;
+		padding: 1px 6px;
+		margin-left: 4px;
+	}
+
+	.dg-plugin-badge.is-region {
+		background: var(--interactive-accent);
+		color: var(--text-on-accent, #fff);
+	}
+
+	.dg-plugin-region-notice {
+		font-size: 0.85em;
+		color: var(--text-warning, var(--text-muted));
+		margin-top: 4px;
+	}
+
+	.dg-plugin-conflict-choice {
+		display: flex;
+		align-items: flex-start;
+		gap: 8px;
+		margin: 0 0 10px;
+		font-size: 0.92em;
+	}
+
+	.dg-plugin-conflict-choice input {
+		margin-top: 3px;
+	}
+
+	.dg-plugin-description {
+		font-size: 0.9em;
+	}
+
+	.dg-plugin-row-actions {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex-wrap: wrap;
+	}
+
+	.dg-plugin-toggle {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		font-size: 0.9em;
+	}
+
+	.dg-plugin-settings {
+		border-top: 1px solid var(--background-modifier-border);
+		margin-top: 10px;
+		padding-top: 10px;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.dg-plugin-setting {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 16px;
+	}
+
+	.dg-plugin-setting > span {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.dg-plugin-setting-name {
+		font-weight: 500;
+	}
+
+	.dg-plugin-setting-desc {
+		color: var(--text-muted);
+		font-size: 0.85em;
+	}
+
+	.dg-plugin-install-row {
+		display: flex;
+		gap: 8px;
+	}
+
+	.dg-plugin-install-row input {
+		flex: 1;
+	}
+
+	.dg-plugin-confirm {
+		border: 1px solid var(--background-modifier-border);
+		border-left: 3px solid var(--interactive-accent);
+		border-radius: 8px;
+		padding: 10px 14px;
+	}
+
+	.dg-plugin-confirm-title {
+		margin-top: 0;
+	}
+
+	.dg-plugin-confirm-warning {
+		color: var(--text-warning, var(--text-muted));
+	}
+
+	.dg-plugin-confirm-actions {
+		display: flex;
+		gap: 8px;
+	}
+
+	.dg-plugin-search {
+		width: 100%;
+	}
+
+	.dg-plugin-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+		gap: 12px;
+	}
+
+	.dg-plugin-card {
+		border: 1px solid var(--background-modifier-border);
+		border-radius: 8px;
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.dg-plugin-card-image {
+		width: 100%;
+		height: 90px;
+		object-fit: cover;
+	}
+
+	.dg-plugin-card-body {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		padding: 8px 10px;
+	}
+</style>

--- a/src/views/GardenPluginSettings/InstallPluginModal.ts
+++ b/src/views/GardenPluginSettings/InstallPluginModal.ts
@@ -1,0 +1,60 @@
+import { App, Modal } from "obsidian";
+import { mount, unmount } from "svelte";
+import InstallPluginView from "./InstallPluginView.svelte";
+import { GardenPluginManager } from "../../gardenPlugins/GardenPluginManager";
+import { RepositoryConnection } from "../../repositoryConnection/RepositoryConnection";
+import PublishPlatformConnectionFactory from "../../repositoryConnection/PublishPlatformConnectionFactory";
+import DigitalGardenSettings from "../../models/settings";
+
+/**
+ * Standalone "paste a GitHub URL, install a garden plugin" dialog, opened
+ * by the "Install garden plugin from URL" command. The full management UI
+ * lives in the settings tab's Plugins section.
+ */
+export class InstallPluginModal {
+	modal: Modal;
+	private view: ReturnType<typeof mount> | undefined;
+
+	constructor(
+		private app: App,
+		private settings: DigitalGardenSettings,
+	) {
+		this.modal = new Modal(app);
+		this.modal.titleEl.innerText = "Install Garden Plugin";
+	}
+
+	open = async () => {
+		const connection =
+			await PublishPlatformConnectionFactory.createPublishPlatformConnection(
+				this.settings,
+			);
+
+		const manager = new GardenPluginManager(
+			new RepositoryConnection(connection),
+			this.settings,
+		);
+
+		this.modal.onClose = () => {
+			if (this.view) {
+				unmount(this.view);
+				this.view = undefined;
+			}
+		};
+
+		this.modal.onOpen = () => {
+			this.modal.contentEl.empty();
+			this.modal.contentEl.addClass("dg-garden-plugins-modal");
+
+			this.view = mount(InstallPluginView, {
+				target: this.modal.contentEl,
+				props: {
+					manager,
+					settings: this.settings,
+					close: () => this.modal.close(),
+				},
+			});
+		};
+
+		this.modal.open();
+	};
+}

--- a/src/views/GardenPluginSettings/InstallPluginView.svelte
+++ b/src/views/GardenPluginSettings/InstallPluginView.svelte
@@ -1,0 +1,275 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { Notice } from "obsidian";
+	import type {
+		GardenPluginManager,
+		RemoteGardenPlugin,
+	} from "../../gardenPlugins/GardenPluginManager";
+	import type {
+		GardenPluginRegistryEntry,
+		InstalledGardenPlugin,
+	} from "../../models/gardenPlugin";
+	import type DigitalGardenSettings from "../../models/settings";
+	import { getRegionConflicts, regionsOf } from "../../gardenPlugins/regions";
+	import { buildTriggeredNotice } from "../../gardenPlugins/notices";
+
+	export let manager: GardenPluginManager;
+	export let settings: DigitalGardenSettings;
+	export let close: () => void;
+
+	let input = "";
+	let inputEl: HTMLInputElement;
+	let inspecting = false;
+	let installing = false;
+	let error: string | null = null;
+	let pending: RemoteGardenPlugin | null = null;
+	let existingEntry: GardenPluginRegistryEntry | undefined;
+	let conflicts: InstalledGardenPlugin[] = [];
+	let disableConflicts = true;
+
+	onMount(() => {
+		inputEl?.focus();
+	});
+
+	async function inspect() {
+		if (!input.trim()) {
+			return;
+		}
+
+		inspecting = true;
+		error = null;
+		pending = null;
+		disableConflicts = true;
+
+		try {
+			const remote = await manager.inspectRemotePlugin(input);
+			const installed = await manager.listInstalled();
+
+			existingEntry = installed.find(
+				(plugin) => plugin.manifest.id === remote.manifest.id,
+			)?.registryEntry;
+			conflicts = getRegionConflicts(remote.manifest, installed);
+			pending = remote;
+		} catch (err) {
+			error = err instanceof Error ? err.message : "Unknown error";
+		}
+
+		inspecting = false;
+	}
+
+	async function confirmInstall() {
+		if (!pending) {
+			return;
+		}
+
+		installing = true;
+
+		const disableIds = disableConflicts
+			? conflicts.map((conflict) => conflict.manifest.id)
+			: [];
+
+		try {
+			await manager.install(pending, existingEntry, disableIds);
+
+			new Notice(
+				`${existingEntry ? "Updated" : "Installed"} ${
+					pending.manifest.name
+				} ${pending.manifest.version}. ${buildTriggeredNotice(
+					settings,
+				)}`,
+			);
+			close();
+		} catch (err) {
+			error = err instanceof Error ? err.message : "Install failed";
+			installing = false;
+		}
+	}
+</script>
+
+<div class="dg-install-plugin">
+	<p class="dg-install-intro">
+		Paste the GitHub URL of a garden plugin. It will be reviewed before
+		anything is written to your garden repository.
+	</p>
+
+	<form class="dg-install-row" on:submit|preventDefault={inspect}>
+		<input
+			type="text"
+			placeholder="https://github.com/user/garden-plugin-example"
+			bind:value={input}
+			bind:this={inputEl}
+			disabled={inspecting || installing}
+		/>
+
+		<button
+			type="submit"
+			class="mod-cta"
+			disabled={inspecting || installing || !input.trim()}
+		>
+			{#if inspecting}
+				<span class="dg-spinner" aria-hidden="true"></span> Checking…
+			{:else}
+				Check plugin
+			{/if}
+		</button>
+	</form>
+
+	{#if error}
+		<p class="dg-install-error">{error}</p>
+	{/if}
+
+	{#if pending}
+		<div class="dg-install-confirm">
+			<p class="dg-install-confirm-title">
+				{existingEntry ? "Update" : "Install"}
+				<strong>{pending.manifest.name}</strong>
+				v{pending.manifest.version} by {pending.manifest.author}?
+			</p>
+
+			<p>{pending.manifest.description}</p>
+
+			<p class="dg-install-warning">
+				⚠️ Plugins run their own code in your site's build and in your
+				visitors' browsers. Only install plugins from authors you trust
+				— review the code at
+				<a href={`https://github.com/${pending.owner}/${pending.repo}`}
+					>{pending.owner}/{pending.repo}</a
+				>
+				({pending.files.length} files, ref
+				<code>{pending.ref}</code>).
+			</p>
+
+			{#if conflicts.length > 0}
+				<label class="dg-install-conflict-choice">
+					<input type="checkbox" bind:checked={disableConflicts} />
+					<span>
+						{pending.manifest.name} replaces
+						<strong
+							>{conflicts
+								.map((c) => c.manifest.name)
+								.join(", ")}</strong
+						>
+						({regionsOf(pending.manifest).join(", ")}). Disable {conflicts.length ===
+						1
+							? "it"
+							: "them"} so {pending.manifest.name} takes over right
+						away.
+					</span>
+				</label>
+			{/if}
+
+			<div class="dg-install-actions">
+				<button
+					class="mod-cta"
+					disabled={installing}
+					on:click={confirmInstall}
+				>
+					{#if installing}
+						<span class="dg-spinner" aria-hidden="true"></span>
+						Installing…
+					{:else}
+						{existingEntry ? "Update plugin" : "Install plugin"}
+					{/if}
+				</button>
+
+				<button disabled={installing} on:click={() => (pending = null)}
+					>Cancel</button
+				>
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.dg-install-plugin {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+		min-width: min(440px, 80vw);
+	}
+
+	.dg-install-intro {
+		color: var(--text-muted);
+		margin: 0;
+	}
+
+	.dg-install-row {
+		display: flex;
+		gap: 8px;
+	}
+
+	.dg-install-row input {
+		flex: 1;
+	}
+
+	.dg-install-row button {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		white-space: nowrap;
+	}
+
+	.dg-install-error {
+		color: var(--text-error);
+		margin: 0;
+	}
+
+	.dg-install-confirm {
+		border: 1px solid var(--background-modifier-border);
+		border-left: 3px solid var(--interactive-accent);
+		border-radius: 8px;
+		padding: 10px 14px;
+	}
+
+	.dg-install-confirm-title {
+		margin-top: 0;
+	}
+
+	.dg-install-warning {
+		color: var(--text-warning, var(--text-muted));
+	}
+
+	.dg-install-conflict-choice {
+		display: flex;
+		align-items: flex-start;
+		gap: 8px;
+		margin: 0 0 10px;
+		font-size: 0.92em;
+	}
+
+	.dg-install-conflict-choice input {
+		margin-top: 3px;
+	}
+
+	.dg-install-actions {
+		display: flex;
+		gap: 8px;
+	}
+
+	.dg-install-actions button {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.dg-spinner {
+		width: 12px;
+		height: 12px;
+		border: 2px solid currentColor;
+		border-top-color: transparent;
+		border-radius: 50%;
+		animation: dg-spin 0.7s linear infinite;
+	}
+
+	@keyframes dg-spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.dg-spinner {
+			animation-duration: 2.5s;
+		}
+	}
+</style>

--- a/src/views/SettingsView/SettingView.ts
+++ b/src/views/SettingsView/SettingView.ts
@@ -40,6 +40,8 @@ import { PublishPlatform } from "src/models/PublishPlatform";
 import PublishPlatformConnectionFactory from "../../repositoryConnection/PublishPlatformConnectionFactory";
 import { NavigationOrderModal } from "../NavigationOrder/NavigationOrderModal";
 import { RepositoryConnection } from "../../repositoryConnection/RepositoryConnection";
+import { GardenPluginsModal } from "../GardenPluginSettings/GardenPluginsModal";
+import { GardenPluginManager } from "../../gardenPlugins/GardenPluginManager";
 
 interface IObsidianTheme {
 	name: string;
@@ -177,7 +179,12 @@ export default class SettingView {
 		this.initializeSlugifySetting();
 
 		this.settingsRootElement
-			.createEl("h3", { text: "Features" })
+			.createEl("h3", { text: "Plugins" })
+			.prepend(this.getIcon("blocks"));
+		this.initializeGardenPluginSettings();
+
+		this.settingsRootElement
+			.createEl("h3", { text: "Display" })
 			.prepend(this.getIcon("star"));
 		this.initializeDefaultNoteSettings();
 
@@ -527,35 +534,8 @@ export default class SettingView {
 				});
 			});
 
-		new Setting(noteSettingsModal.contentEl)
-			.setName("Enable search (dg-enable-search)")
-			.setDesc(
-				"When turned on, users will be able to search through the content of your site.",
-			)
-			.addToggle((t) => {
-				toggles["dgEnableSearch"] = t;
-				t.setValue(this.settings.defaultNoteSettings.dgEnableSearch);
-
-				t.onChange((val) => {
-					this.settings.defaultNoteSettings.dgEnableSearch = val;
-					markAsChanged();
-				});
-			});
-
-		new Setting(noteSettingsModal.contentEl)
-			.setName("Enable link preview (dg-link-preview)")
-			.setDesc(
-				"When turned on, hovering over links to notes in your garden shows a scrollable preview.",
-			)
-			.addToggle((t) => {
-				toggles["dgLinkPreview"] = t;
-				t.setValue(this.settings.defaultNoteSettings.dgLinkPreview);
-
-				t.onChange((val) => {
-					this.settings.defaultNoteSettings.dgLinkPreview = val;
-					markAsChanged();
-				});
-			});
+		// Search and link preview are garden plugins now — their toggles
+		// live in the Plugins section, next to the plugin they belong to.
 
 		new Setting(noteSettingsModal.contentEl)
 			.setName("Show Tags (dg-show-tags)")
@@ -2153,6 +2133,45 @@ export default class SettingView {
 						await this.saveSettings();
 					}),
 			);
+	}
+
+	private initializeGardenPluginSettings() {
+		new Setting(this.settingsRootElement)
+			.setName("Garden Plugins")
+			.setDesc(
+				"Install, configure and manage the plugins that power your garden's features. Read from your garden repository.",
+			)
+			.addButton((cb) => {
+				cb.setButtonText("Manage plugins");
+
+				cb.onClick(async () => {
+					const connection =
+						await PublishPlatformConnectionFactory.createPublishPlatformConnection(
+							this.settings,
+						);
+
+					const manager = new GardenPluginManager(
+						new RepositoryConnection(connection),
+						this.settings,
+					);
+
+					const modal = new GardenPluginsModal(
+						this.app,
+						manager,
+						this.settings,
+						this.saveSettings,
+						async () => {
+							await this.saveSiteSettingsAndUpdateEnv(
+								this.app.metadataCache,
+								this.settings,
+								this.saveSettings,
+							);
+						},
+					);
+
+					modal.open();
+				});
+			});
 	}
 
 	private async openNavigationOrderModal() {


### PR DESCRIPTION
Implements the installer side of the garden plugin system (template side: oleeskild/digitalgarden#411).

## Settings tab

The "Features" section becomes **Plugins**; the remaining core toggles move to a slimmed **Display** section. Search and link-preview defaults now live in their plugins' settings.

The Manage Plugins modal (Svelte, Installed / Browse & install tabs):

- **Installed** — enumerated live from the garden repo (`src/plugins/*/garden-plugin.json` + the `plugins.json` registry; the repo is the source of truth, no local cache). Enable/disable toggles, generic settings forms rendered from each manifest, per-note default toggles for declared `noteSettings`, update/uninstall for community plugins, "Core plugin" and "Provides navigation" badges, and inline notices when an enabled plugin's region is occupied by another.
- **Browse & install** — paste any GitHub URL shape, or one-click install from the community gallery ([digitalgarden-plugins](https://github.com/oleeskild/digitalgarden-plugins)). Inspection resolves the latest release, validates the manifest (required fields, id rules incl. reserved `dg-` prefix, path safety, size caps), then a security confirmation shows author/files/ref with a link to the source. Install copies files verbatim in **one atomic commit** — plugin code is never executed. When the incoming plugin claims an occupied region (e.g. a custom navigation), the confirmation offers to disable the current provider in the same commit.

## Also

- New command **Install garden plugin from URL** with a standalone dialog.
- Platform-aware notices ("Forestry is rebuilding your garden…" vs "A site build has been triggered…"); the whole feature works on Forestry through the existing GitHub-shaped connection.
- `RepositoryConnection.getFile` now cache-busts (GitHub serves `max-age=60`, Electron honors it), fixing intermittent stale-sha edit conflicts on registry and `.env` writes.
- New generic `RepositoryConnection.commitChanges` (blobs → tree → commit → ref) for atomic multi-file writes.
- Skeleton loading states for the plugin lists.

## Testing

254 jest tests pass, including new suites for URL parsing / manifest validation, `GardenPluginManager` (enumeration, enable/disable, install with orphan deletion and region handover, uninstall — across `contentBaseDir` layouts), and region resolution. Exercised end to end against a live test garden (digitalgarden-plugin-test on Vercel) including community installs, region handover, and toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgfZCHzqF8kRyEhgcSKKwP
