### PR TITLE
Authenticate template and plugin fetches with the user's GitHub token

### DIFF
--- a/src/dg-testVault/.obsidian/themes/Omarchy/manifest.json
+++ b/src/dg-testVault/.obsidian/themes/Omarchy/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "Omarchy",
+  "version": "1.0.0",
+  "minAppVersion": "0.16.0",
+  "description": "Automatically syncs with your current Omarchy system theme colors and fonts",
+  "author": "Omarchy",
+  "authorUrl": "https://omarchy.org"
+}

--- a/src/dg-testVault/.obsidian/themes/Omarchy/theme.css
+++ b/src/dg-testVault/.obsidian/themes/Omarchy/theme.css
@@ -1,0 +1,99 @@
+/* Omarchy Theme for Obsidian */
+
+.theme-dark, .theme-light {
+  /* Core colors */
+  --background-primary: #191510;
+  --background-primary-alt: #191510;
+  --background-secondary: #191510;
+  --background-secondary-alt: #191510;
+  --text-normal: #d3c0a8;
+
+  /* Selection colors */
+  --text-selection: #3a2f22;
+
+  /* Border color */
+  --background-modifier-border: #867658;
+
+  /* Semantic heading colors */
+  --text-title-h1: #db6c4f;
+  --text-title-h2: #9cba64;
+  --text-title-h3: #d9ab5e;
+  --text-title-h4: #79a5cc;
+  --text-title-h5: #cd8ba4;
+  --text-title-h6: #cd8ba4;
+
+  /* Links and accents */
+  --text-link: #79a5cc;
+  --text-accent: #e09355;
+  --text-accent-hover: #e09355;
+  --interactive-accent: #e09355;
+  --interactive-accent-hover: #e09355;
+
+  /* Muted text */
+  --text-muted: color-mix(in srgb, #d3c0a8 70%, transparent);
+  --text-faint: color-mix(in srgb, #d3c0a8 55%, transparent);
+
+  /* Code */
+  --code-normal: #63b8a6;
+
+  /* Errors and success */
+  --text-error: #db6c4f;
+  --text-error-hover: #db6c4f;
+  --text-success: #9cba64;
+
+  /* Tags */
+  --tag-color: #63b8a6;
+  --tag-background: #867658;
+
+  /* Graph */
+  --graph-line: #867658;
+  --graph-node: #e09355;
+  --graph-node-focused: #79a5cc;
+  --graph-node-tag: #63b8a6;
+  --graph-node-attachment: #9cba64;
+}
+
+/* Headers */
+.cm-header-1, .markdown-rendered h1 { color: var(--text-title-h1); }
+.cm-header-2, .markdown-rendered h2 { color: var(--text-title-h2); }
+.cm-header-3, .markdown-rendered h3 { color: var(--text-title-h3); }
+.cm-header-4, .markdown-rendered h4 { color: var(--text-title-h4); }
+.cm-header-5, .markdown-rendered h5 { color: var(--text-title-h5); }
+.cm-header-6, .markdown-rendered h6 { color: var(--text-title-h6); }
+
+/* Code blocks */
+.markdown-rendered code {
+  color: #63b8a6;
+}
+
+/* Syntax highlighting */
+.cm-s-obsidian span.cm-keyword { color: #db6c4f; }
+.cm-s-obsidian span.cm-string { color: #9cba64; }
+.cm-s-obsidian span.cm-number { color: #d9ab5e; }
+.cm-s-obsidian span.cm-comment { color: #867658; }
+.cm-s-obsidian span.cm-operator { color: #79a5cc; }
+.cm-s-obsidian span.cm-def { color: #79a5cc; }
+
+/* Links */
+.markdown-rendered a {
+  color: var(--text-link);
+}
+
+/* Blockquotes */
+.markdown-rendered blockquote {
+  border-left-color: #e09355;
+}
+
+/* Active elements */
+.workspace-leaf.mod-active .workspace-leaf-header-title {
+  color: var(--interactive-accent);
+}
+
+.nav-file-title.is-active {
+  color: var(--interactive-accent);
+}
+
+/* Search results */
+.search-result-file-title {
+  color: var(--interactive-accent);
+}

--- a/src/gardenPlugins/GardenPluginManager.ts
+++ b/src/gardenPlugins/GardenPluginManager.ts
@@ -41,7 +41,7 @@ export interface RemoteGardenPlugin {
 
 type PathSettings = Pick<
 	DigitalGardenSettings,
-	"contentBaseDir" | "publishPlatform"
+	"contentBaseDir" | "publishPlatform" | "githubToken"
 >;
 
 /**
@@ -64,6 +64,7 @@ export class GardenPluginManager {
 				PublishPlatformConnectionFactory.createGitHubConnection(
 					owner,
 					repo,
+					PublishPlatformConnectionFactory.githubTokenFor(settings),
 				),
 			),
 	) {}

--- a/src/repositoryConnection/DigitalGardenSiteManager.ts
+++ b/src/repositoryConnection/DigitalGardenSiteManager.ts
@@ -52,7 +52,9 @@ export default class DigitalGardenSiteManager {
 		this.rewriteRules = getRewriteRules(settings.pathRewriteRules);
 
 		this.baseGardenConnection = new RepositoryConnection(
-			PublishPlatformConnectionFactory.createBaseGardenConnection(),
+			PublishPlatformConnectionFactory.createBaseGardenConnection(
+				PublishPlatformConnectionFactory.githubTokenFor(settings),
+			),
 		);
 		this.userGardenConnection = null;
 		this.templateUpdater = null;

--- a/src/repositoryConnection/PublishPlatformConnectionFactory.ts
+++ b/src/repositoryConnection/PublishPlatformConnectionFactory.ts
@@ -10,20 +10,50 @@ const oktokitLogger = Logger.get("octokit");
 const DEFAULT_FORESTRY_BASE_URL = "https://api.forestry.md/app";
 
 export default class PublishPlatformConnectionFactory {
-	static createBaseGardenConnection(): IPublishPlatformConnection {
-		return this.createGitHubConnection("oleeskild", "digitalgarden");
+	static createBaseGardenConnection(
+		token?: string,
+	): IPublishPlatformConnection {
+		return this.createGitHubConnection("oleeskild", "digitalgarden", token);
 	}
 
-	/** Unauthenticated connection to an arbitrary public GitHub repo. */
+	/**
+	 * Connection to an arbitrary public GitHub repo. Pass the user's token
+	 * when available: authenticated requests get 5,000 req/h instead of the
+	 * 60 req/h per-IP unauthenticated limit, which template updates (one
+	 * request per changed file) can exhaust.
+	 */
 	static createGitHubConnection(
 		userName: string,
 		pageName: string,
+		token?: string,
 	): IPublishPlatformConnection {
 		return {
-			octoKit: new Octokit({ log: oktokitLogger }),
+			octoKit: new Octokit({
+				auth: token || undefined,
+				log: oktokitLogger,
+			}),
 			userName,
 			pageName,
 		};
+	}
+
+	/**
+	 * The user's GitHub token, when it can be used against github.com.
+	 * Only self-hosted setups are known to hold a valid GitHub token —
+	 * a Forestry user's stored token may be stale, and sending an invalid
+	 * token turns rate limiting into hard 401s.
+	 */
+	static githubTokenFor(
+		settings: Pick<
+			DigitalGardenSettings,
+			"publishPlatform" | "githubToken"
+		>,
+	): string | undefined {
+		if (settings.publishPlatform !== PublishPlatform.SelfHosted) {
+			return undefined;
+		}
+
+		return settings.githubToken || undefined;
 	}
 	static async createPublishPlatformConnection(
 		settings: DigitalGardenSettings,

--- a/src/views/SettingsView/SettingView.ts
+++ b/src/views/SettingsView/SettingView.ts
@@ -1896,7 +1896,11 @@ export default class SettingView {
 			base64SettingsFaviconContent = arrayBufferToBase64(faviconContent);
 		} else {
 			const baseConnection =
-				PublishPlatformConnectionFactory.createBaseGardenConnection();
+				PublishPlatformConnectionFactory.createBaseGardenConnection(
+					PublishPlatformConnectionFactory.githubTokenFor(
+						this.settings,
+					),
+				);
 
 			const defaultFavicon = await baseConnection.octoKit.request(
 				"GET /repos/{owner}/{repo}/contents/{path}",


### PR DESCRIPTION
Template update checks/updates and community-plugin source fetches ran unauthenticated (60 req/h per IP shared bucket). Since an update fetches one file per changed path (~80 files after the plugin system), users hit 403 rate-limit errors. Now uses the user's token (5,000 req/h) on self-hosted setups; Forestry keeps unauthenticated access because its stored GitHub token may be stale, and an invalid token would turn rate limiting into hard 401s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgfZCHzqF8kRyEhgcSKKwP