### PR TITLE
feat: show Forestry publish status in the plugin

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -30,6 +30,11 @@ import PublishPlatformConnectionFactory from "src/repositoryConnection/PublishPl
 import { PublicationCenterView } from "src/views/PublicationCenterView/PublicationCenterView";
 import { VIEW_TYPE } from "src/views/PublicationCenterView/constants";
 import { WorkspaceLeaf } from "obsidian";
+import ForestryApi from "src/forestry/ForestryApi";
+import {
+	SiteUpdateTracker,
+	type SiteUpdatePhase,
+} from "src/forestry/SiteUpdateTracker";
 
 // Process environment variables are provided through esbuild's define feature
 // See esbuild.config.mjs
@@ -140,6 +145,12 @@ export default class DigitalGarden extends Plugin {
 
 	isPublishing: boolean = false;
 
+	/** Tracks garden site updates; only set for Forestry.md-hosted gardens. */
+	siteUpdateTracker: SiteUpdateTracker | null = null;
+	private siteStatusBarItem: HTMLElement | null = null;
+	private siteStatusUnsubscribe: (() => void) | null = null;
+	private siteTrackerApiKey: string | null = null;
+
 	async onload() {
 		this.appVersion = this.manifest.version;
 
@@ -170,8 +181,103 @@ export default class DigitalGarden extends Plugin {
 			(leaf: WorkspaceLeaf) => new PublicationCenterView(leaf, this),
 		);
 
+		this.syncSiteUpdateTracker();
+
 		this.checkForTemplateUpdates();
 		this.registerDevAutoExport();
+	}
+
+	/**
+	 * Create or tear down the site-update tracker and its status bar item so
+	 * they match the current settings. Called on load and after every
+	 * settings save, so switching publish platform (or changing the API key)
+	 * takes effect immediately.
+	 */
+	syncSiteUpdateTracker() {
+		const apiKey = this.settings.forestrySettings.apiKey;
+
+		const enabled =
+			this.settings.publishPlatform === PublishPlatform.ForestryMd &&
+			!!apiKey;
+
+		if (
+			enabled &&
+			this.siteUpdateTracker &&
+			this.siteTrackerApiKey === apiKey
+		) {
+			return;
+		}
+
+		this.teardownSiteUpdateTracker();
+
+		if (enabled) {
+			this.createSiteUpdateTracker(apiKey);
+		}
+
+		// Open Publication Centers hold the old tracker (or none) as a prop;
+		// remount them so the publish-status strip appears/disappears.
+		for (const leaf of this.app.workspace.getLeavesOfType(VIEW_TYPE)) {
+			if (leaf.view instanceof PublicationCenterView) {
+				leaf.view.remountComponent();
+			}
+		}
+	}
+
+	private teardownSiteUpdateTracker() {
+		this.siteStatusUnsubscribe?.();
+		this.siteStatusUnsubscribe = null;
+		this.siteStatusBarItem?.remove();
+		this.siteStatusBarItem = null;
+		this.siteUpdateTracker?.dispose();
+		this.siteUpdateTracker = null;
+		this.siteTrackerApiKey = null;
+	}
+
+	/**
+	 * For Forestry.md gardens: start the plugin-wide site-update tracker and
+	 * mirror its state into a persistent status bar item, so publishes from
+	 * any command report whether the site actually went live.
+	 */
+	private createSiteUpdateTracker(apiKey: string) {
+		this.siteUpdateTracker = new SiteUpdateTracker(new ForestryApi(apiKey));
+		this.siteTrackerApiKey = apiKey;
+
+		const statusBarItem = this.addStatusBarItem();
+		statusBarItem.addClass("dg-site-status");
+
+		statusBarItem.setAttribute(
+			"aria-label",
+			"Forestry site — click for publish status",
+		);
+		statusBarItem.setAttribute("data-tooltip-position", "top");
+
+		statusBarItem.onClickEvent(() => {
+			this.activatePublicationCenter();
+		});
+
+		const phaseLabels: Record<SiteUpdatePhase, string> = {
+			idle: "",
+			queued: " Queued…",
+			updating: " Publishing…",
+			live: " Live",
+			failed: " Publish failed",
+		};
+
+		this.siteStatusUnsubscribe = this.siteUpdateTracker.store.subscribe(
+			(state) => {
+				statusBarItem.toggleClass(
+					"dg-site-status-updating",
+					state.phase === "queued" || state.phase === "updating",
+				);
+
+				statusBarItem.toggleClass(
+					"dg-site-status-failed",
+					state.phase === "failed",
+				);
+				statusBarItem.setText(`🌱${phaseLabels[state.phase]}`);
+			},
+		);
+		this.siteStatusBarItem = statusBarItem;
 	}
 
 	private async checkForTemplateUpdates() {
@@ -200,7 +306,9 @@ export default class DigitalGarden extends Plugin {
 		}
 	}
 
-	onunload() {}
+	onunload() {
+		this.teardownSiteUpdateTracker();
+	}
 
 	async loadSettings() {
 		this.settings = Object.assign(
@@ -212,6 +320,7 @@ export default class DigitalGarden extends Plugin {
 
 	async saveSettings(): Promise<void> {
 		await this.saveData(this.settings);
+		this.syncSiteUpdateTracker();
 	}
 
 	async addCommands() {
@@ -374,6 +483,7 @@ export default class DigitalGarden extends Plugin {
 					}
 
 					statusBar.finish(8000);
+					this.siteUpdateTracker?.notifyPublished();
 
 					new Notice(
 						`Successfully published ${filesToPublish.length} notes to your garden.`,
@@ -611,6 +721,7 @@ export default class DigitalGarden extends Plugin {
 
 			if (publishSuccessful) {
 				new Notice(`Successfully published note to your garden.`);
+				this.siteUpdateTracker?.notifyPublished();
 			} else {
 				new Notice("Unable to publish note, something went wrong.");
 			}

--- a/src/forestry/DeployInfo.ts
+++ b/src/forestry/DeployInfo.ts
@@ -1,0 +1,27 @@
+export interface IFriendlyBuildError {
+	message: string;
+	hint?: string | null;
+	affectedNotes?: string[] | null;
+}
+
+/**
+ * A single build/deploy of the user's garden, as reported by the Forestry API
+ * (GET /app/pages/deploys). Statuses: "pending" (queued, waiting for the
+ * debounce window), "inprogress", "completed", "failed", "cancelled"
+ * (superseded by a newer build).
+ */
+export interface IDeployInfo {
+	runId: string;
+	status: string;
+	conclusion?: string | null;
+	createdAt: string;
+	updatedAt?: string | null;
+	branch?: string | null;
+	durationSeconds?: number | null;
+	errorMessage?: string | null;
+	friendlyError?: IFriendlyBuildError | null;
+}
+
+export interface IDeploysResponse {
+	value: IDeployInfo[];
+}

--- a/src/forestry/ForestryApi.ts
+++ b/src/forestry/ForestryApi.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance, AxiosResponse } from "axios";
 import IPageInfoResponse from "src/models/PageInfo";
 import { IUserLimitsResponse } from "src/forestry/UserLimitsResponse";
+import { IDeployInfo, IDeploysResponse } from "src/forestry/DeployInfo";
 import Logger from "js-logger";
 
 // Default base URL to use as fallback
@@ -33,6 +34,27 @@ export default class ForestryApi {
 			}
 
 			return response.data;
+		} catch (e) {
+			Logger.error(e);
+
+			return null;
+		}
+	}
+
+	async getDeploys(
+		branch: "active" | "main" = "active",
+		limit = 10,
+	): Promise<IDeployInfo[] | null> {
+		try {
+			const response = (await this.client.get("pages/deploys", {
+				params: { branch, limit },
+			})) as AxiosResponse<IDeploysResponse>;
+
+			if (response.status !== 200) {
+				return null;
+			}
+
+			return response.data.value;
 		} catch (e) {
 			Logger.error(e);
 

--- a/src/forestry/SiteUpdateTracker.ts
+++ b/src/forestry/SiteUpdateTracker.ts
@@ -1,0 +1,258 @@
+import { Notice } from "obsidian";
+import { writable, type Writable } from "svelte/store";
+import type ForestryApi from "./ForestryApi";
+import type { IDeployInfo } from "./DeployInfo";
+import type { IUserLimitsResponse } from "./UserLimitsResponse";
+
+export type SiteUpdatePhase =
+	| "idle"
+	| "queued"
+	| "updating"
+	| "live"
+	| "failed";
+
+export interface SiteUpdateState {
+	builds: IDeployInfo[];
+	limits: IUserLimitsResponse | null;
+	loaded: boolean;
+	loadFailed: boolean;
+	phase: SiteUpdatePhase;
+	/** True while waiting for the update from a fresh publish to appear. */
+	awaitingNewBuild: boolean;
+	/** Bumped on each tracked failure; the UI reacts to changes. */
+	failureCount: number;
+}
+
+const POLL_INTERVAL_MS = 5000;
+const POLL_TIMEOUT_MS = 10 * 60 * 1000;
+const LIVE_PHASE_MS = 2 * 60 * 1000;
+
+/**
+ * Plugin-wide tracker for the garden's site updates (Forestry builds).
+ * Owns the polling loop and notices so every publish path — commands,
+ * Quick Publish, the Publication Center — reports through one place;
+ * views and the status bar render from {@link store}.
+ *
+ * After a publish, the update for the new commit doesn't exist until the
+ * server's webhook debounce fires, so it first waits for an unknown runId
+ * to appear, then follows it until it settles.
+ */
+export class SiteUpdateTracker {
+	readonly store: Writable<SiteUpdateState>;
+
+	private api: ForestryApi;
+	private builds: IDeployInfo[] = [];
+	private knownRunIds = new Set<string>();
+	private awaitingNewBuild = false;
+	private watchedRunId: string | null = null;
+	private pollTimer: ReturnType<typeof setInterval> | null = null;
+	private pollDeadline = 0;
+	private liveTimer: ReturnType<typeof setTimeout> | null = null;
+
+	constructor(api: ForestryApi) {
+		this.api = api;
+
+		this.store = writable<SiteUpdateState>({
+			builds: [],
+			limits: null,
+			loaded: false,
+			loadFailed: false,
+			phase: "idle",
+			awaitingNewBuild: false,
+			failureCount: 0,
+		});
+
+		void this.init();
+	}
+
+	/** Call after anything was pushed to the garden repo. */
+	notifyPublished() {
+		if (this.liveTimer !== null) {
+			clearTimeout(this.liveTimer);
+			this.liveTimer = null;
+		}
+		this.knownRunIds = new Set(this.builds.map((b) => b.runId));
+		this.watchedRunId = null;
+		this.awaitingNewBuild = true;
+		this.patch({ awaitingNewBuild: true, phase: "queued" });
+		this.startPolling();
+		void this.tick();
+	}
+
+	/** One-off refresh of the update list (e.g. when a view regains focus). */
+	refresh() {
+		void this.fetchBuilds();
+	}
+
+	dispose() {
+		if (this.pollTimer !== null) clearInterval(this.pollTimer);
+
+		if (this.liveTimer !== null) clearTimeout(this.liveTimer);
+		this.pollTimer = null;
+		this.liveTimer = null;
+	}
+
+	private patch(partial: Partial<SiteUpdateState>) {
+		this.store.update((s) => ({ ...s, ...partial }));
+	}
+
+	private isSettled(build: IDeployInfo): boolean {
+		return (
+			build.status === "completed" ||
+			build.status === "failed" ||
+			build.status === "cancelled"
+		);
+	}
+
+	private async init() {
+		await this.fetchBuilds();
+		this.knownRunIds = new Set(this.builds.map((b) => b.runId));
+
+		// Catch up on updates already in flight (or a standing failure)
+		// when the plugin loads — quietly, without notices.
+		const latest = this.builds[0];
+
+		if (latest && !this.isSettled(latest)) {
+			this.patch({
+				phase: latest.status === "inprogress" ? "updating" : "queued",
+			});
+			this.startPolling();
+		} else if (latest?.status === "failed") {
+			this.patch({ phase: "failed" });
+		}
+
+		const limits = await this.api.getUserLimits();
+		this.patch({ limits });
+	}
+
+	private async fetchBuilds(): Promise<boolean> {
+		const result = await this.api.getDeploys("active", 10);
+
+		if (result) {
+			this.builds = result;
+			this.patch({ builds: result, loaded: true, loadFailed: false });
+		} else {
+			this.store.update((s) => ({
+				...s,
+				loadFailed: s.loaded ? s.loadFailed : true,
+				loaded: true,
+			}));
+		}
+
+		return result !== null;
+	}
+
+	private startPolling() {
+		this.pollDeadline = Date.now() + POLL_TIMEOUT_MS;
+
+		if (this.pollTimer !== null) return;
+
+		this.pollTimer = setInterval(() => void this.tick(), POLL_INTERVAL_MS);
+	}
+
+	private stopPolling() {
+		if (this.pollTimer !== null) {
+			clearInterval(this.pollTimer);
+			this.pollTimer = null;
+		}
+		this.awaitingNewBuild = false;
+		this.watchedRunId = null;
+		this.patch({ awaitingNewBuild: false });
+	}
+
+	private async tick() {
+		if (Date.now() > this.pollDeadline) {
+			this.stopPolling();
+			this.patch({ phase: "idle" });
+
+			return;
+		}
+
+		if (!(await this.fetchBuilds())) return; // transient error, retry
+
+		if (this.awaitingNewBuild) {
+			const fresh = this.builds.find(
+				(b) => !this.knownRunIds.has(b.runId),
+			);
+
+			if (fresh) {
+				this.awaitingNewBuild = false;
+				this.watchedRunId = fresh.runId;
+				this.patch({ awaitingNewBuild: false });
+			}
+		}
+
+		if (this.watchedRunId) {
+			const watched = this.builds.find(
+				(b) => b.runId === this.watchedRunId,
+			);
+
+			if (watched) {
+				if (!this.isSettled(watched)) {
+					this.patch({
+						phase:
+							watched.status === "inprogress"
+								? "updating"
+								: "queued",
+					});
+				} else if (watched.status === "cancelled") {
+					// Superseded by a newer update (e.g. a second publish);
+					// go back to waiting for the replacement.
+					this.knownRunIds.add(watched.runId);
+					this.watchedRunId = null;
+					this.awaitingNewBuild = true;
+					this.patch({ awaitingNewBuild: true, phase: "queued" });
+				} else {
+					this.announceResult(watched);
+					this.stopPolling();
+				}
+			}
+
+			return;
+		}
+
+		// Passive catch-up (updates we didn't trigger): keep refreshing
+		// until everything settles, without notices.
+		if (!this.awaitingNewBuild) {
+			const latest = this.builds[0];
+
+			if (latest && !this.isSettled(latest)) {
+				this.patch({
+					phase:
+						latest.status === "inprogress" ? "updating" : "queued",
+				});
+			} else {
+				this.stopPolling();
+
+				this.patch({
+					phase: latest?.status === "failed" ? "failed" : "idle",
+				});
+			}
+		}
+	}
+
+	private announceResult(build: IDeployInfo) {
+		if (build.status === "completed") {
+			new Notice("Your site is live 🌱");
+			this.patch({ phase: "live" });
+
+			this.liveTimer = setTimeout(() => {
+				this.liveTimer = null;
+				this.patch({ phase: "idle" });
+			}, LIVE_PHASE_MS);
+		} else {
+			new Notice(
+				build.friendlyError?.message
+					? `Publish failed: ${build.friendlyError.message}`
+					: "Publish failed. See Publish status for details.",
+				8000,
+			);
+
+			this.store.update((s) => ({
+				...s,
+				phase: "failed",
+				failureCount: s.failureCount + 1,
+			}));
+		}
+	}
+}

--- a/src/publisher/Publisher.ts
+++ b/src/publisher/Publisher.ts
@@ -12,7 +12,10 @@ import DigitalGardenSettings from "../models/settings";
 import { Assets, GardenPageCompiler } from "../compiler/GardenPageCompiler";
 import { CompiledPublishFile, PublishFile } from "../publishFile/PublishFile";
 import Logger from "js-logger";
-import { RepositoryConnection } from "../repositoryConnection/RepositoryConnection";
+import {
+	RepositoryConnection,
+	type PublishProgressCallback,
+} from "../repositoryConnection/RepositoryConnection";
 import PublishPlatformConnectionFactory from "src/repositoryConnection/PublishPlatformConnectionFactory";
 import { PublishPlatform } from "../models/PublishPlatform";
 import { LimitReachedError } from "../forestry/LimitReachedError";
@@ -257,7 +260,10 @@ export default class Publisher {
 		}
 	}
 
-	public async publishBatch(files: CompiledPublishFile[]): Promise<boolean> {
+	public async publishBatch(
+		files: CompiledPublishFile[],
+		onProgress?: PublishProgressCallback,
+	): Promise<boolean> {
 		const filesToPublish = files.filter((f) =>
 			isPublishFrontmatterValid(f.frontmatter),
 		);
@@ -278,6 +284,7 @@ export default class Publisher {
 			await userGardenConnection.updateFiles(
 				filesToPublish,
 				remoteImageHashes,
+				onProgress,
 			);
 
 			return true;

--- a/src/repositoryConnection/RepositoryConnection.ts
+++ b/src/repositoryConnection/RepositoryConnection.ts
@@ -18,6 +18,16 @@ interface IPutPayload {
 	message?: string;
 }
 
+/**
+ * Progress reporting for a batch publish: `done`/`total` count upload
+ * operations plus a final commit step, `message` names what just happened.
+ */
+export type PublishProgressCallback = (
+	done: number,
+	total: number,
+	message: string,
+) => void;
+
 export class RepositoryConnection {
 	private userName: string;
 	private pageName: string;
@@ -330,6 +340,7 @@ export class RepositoryConnection {
 	async updateFiles(
 		files: CompiledPublishFile[],
 		remoteImageHashes: Record<string, string> = {},
+		onProgress?: PublishProgressCallback,
 	) {
 		const latestCommit = await this.getLatestCommit();
 
@@ -352,6 +363,17 @@ export class RepositoryConnection {
 		const normalizePath = (path: string) =>
 			path.startsWith("/") ? path.slice(1) : path;
 
+		// Upload progress: one unit per blob upload plus one for the final
+		// commit. totalSteps is assigned below, after the unchanged-image
+		// filter, but before any awaited upload can resolve.
+		let totalSteps = 0;
+		let stepsDone = 0;
+
+		const reportUpload = (path: string) => {
+			stepsDone += 1;
+			onProgress?.(stepsDone, totalSteps, `Uploaded ${path}`);
+		};
+
 		const treePromises = files.map(async (file) => {
 			const [text, _] = file.compiledFile;
 
@@ -365,6 +387,8 @@ export class RepositoryConnection {
 					},
 				);
 
+				reportUpload(file.getPath());
+
 				return {
 					path: `${this.contentBase}${NOTE_PATH_BASE}${normalizePath(
 						file.getPath(),
@@ -376,6 +400,7 @@ export class RepositoryConnection {
 			} catch (error) {
 				throwIfLimitError(error);
 				logger.error(error);
+				reportUpload(file.getPath());
 			}
 		});
 
@@ -412,6 +437,8 @@ export class RepositoryConnection {
 					},
 				);
 
+				reportUpload(asset.path);
+
 				return {
 					path: `${this.contentBase}${IMAGE_PATH_BASE}${normalizePath(
 						asset.path,
@@ -423,11 +450,17 @@ export class RepositoryConnection {
 			} catch (error) {
 				throwIfLimitError(error);
 				logger.error(error);
+				reportUpload(asset.path);
 			}
 		});
 		treePromises.push(...treeAssetPromises);
 
+		totalSteps = files.length + imagesToUpload.length + 1;
+		onProgress?.(0, totalSteps, "Uploading files…");
+
 		const treeList = await Promise.all(treePromises);
+
+		onProgress?.(totalSteps - 1, totalSteps, "Creating commit…");
 
 		//Filter away undefined values
 		const tree = treeList.filter((x) => x !== undefined) as {
@@ -475,6 +508,8 @@ export class RepositoryConnection {
 				sha: newCommit.data.sha,
 			},
 		);
+
+		onProgress?.(totalSteps, totalSteps, "Published");
 	}
 
 	/**

--- a/src/views/DigitalGardenSettingTab.ts
+++ b/src/views/DigitalGardenSettingTab.ts
@@ -37,7 +37,7 @@ export class DigitalGardenSettingTab extends PluginSettingTab {
 			this.app,
 			containerEl,
 			this.plugin.settings,
-			async () => await this.plugin.saveData(this.plugin.settings),
+			async () => await this.plugin.saveSettings(),
 		);
 		const prModal = new UpdateGardenRepositoryModal(this.app);
 

--- a/src/views/PublicationCenterView/PublicationCenter.svelte
+++ b/src/views/PublicationCenterView/PublicationCenter.svelte
@@ -22,12 +22,15 @@
 	import DiffPane from "./DiffPane.svelte";
 	import Notices from "./Notices.svelte";
 	import PublishBar from "./PublishBar.svelte";
+	import RecentBuilds from "./RecentBuilds.svelte";
 	import Tutorial from "./Tutorial.svelte";
+	import type { SiteUpdateTracker } from "../../forestry/SiteUpdateTracker";
 
 	export let siteManager: DigitalGardenSiteManager;
 	export let publisher: Publisher;
 	export let statusManager: IPublishStatusManager;
 	export let openFile: (path: string) => void;
+	export let siteUpdateTracker: SiteUpdateTracker | null = null;
 	export let registerApi: (api: {
 		maybeRefresh: () => void;
 	}) => void = () => {};
@@ -137,6 +140,7 @@
 
 		if (Date.now() - lastRefreshAt < REFRESH_DEBOUNCE_MS) return;
 		loadStatus({ background: true });
+		siteUpdateTracker?.refresh();
 	}
 
 	// Keep the user's choices for files that still exist; default-select any
@@ -179,10 +183,12 @@
 	async function publishSelected() {
 		const plan = buildPublishPlan(selected, annotated);
 
-		progressTotal =
-			plan.notesToPublish.length +
-			plan.notesToDelete.length +
-			plan.imagesToDelete.length;
+		const deletesTotal =
+			plan.notesToDelete.length + plan.imagesToDelete.length;
+
+		// Provisional total; the batch publish reports its real step count
+		// (blob uploads incl. images + the commit) via onProgress below.
+		progressTotal = plan.notesToPublish.length + deletesTotal;
 
 		if (progressTotal === 0) return;
 
@@ -198,9 +204,20 @@
 		progressDone = 0;
 
 		try {
-			progressCurrent = "Publishing notes…";
-			const published = await publisher.publishBatch(plan.notesToPublish);
-			progressDone += plan.notesToPublish.length;
+			progressCurrent = "Preparing upload…";
+
+			let batchSteps = plan.notesToPublish.length;
+
+			const published = await publisher.publishBatch(
+				plan.notesToPublish,
+				(done, total, message) => {
+					batchSteps = total;
+					progressTotal = total + deletesTotal;
+					progressDone = done;
+					progressCurrent = message;
+				},
+			);
+			progressDone = batchSteps;
 
 			if (published) {
 				for (const note of plan.notesToPublish) {
@@ -241,6 +258,12 @@
 			// Reflect everything that succeeded, even if a later step threw.
 			applyOptimisticUpdate(publishedPaths, removedPaths);
 			publishing = false;
+
+			// Anything that reached the repo will trigger a site update;
+			// start tracking it (strip + status bar).
+			if (publishedPaths.size > 0 || removedPaths.size > 0) {
+				siteUpdateTracker?.notifyPublished();
+			}
 		}
 	}
 
@@ -425,6 +448,10 @@
 				/>
 			</div>
 		</div>
+
+		{#if siteUpdateTracker}
+			<RecentBuilds tracker={siteUpdateTracker} />
+		{/if}
 
 		<PublishBar
 			{selectedCount}

--- a/src/views/PublicationCenterView/PublicationCenterView.ts
+++ b/src/views/PublicationCenterView/PublicationCenterView.ts
@@ -4,12 +4,14 @@ import DigitalGardenSettings from "../../models/settings";
 import Publisher from "../../publisher/Publisher";
 import PublishStatusManager from "../../publisher/PublishStatusManager";
 import DigitalGardenSiteManager from "../../repositoryConnection/DigitalGardenSiteManager";
+import type { SiteUpdateTracker } from "../../forestry/SiteUpdateTracker";
 import { VIEW_TYPE, VIEW_DISPLAY_TEXT, VIEW_ICON } from "./constants";
 import PublicationCenter from "./PublicationCenter.svelte";
 
 interface PublicationCenterViewPlugin {
 	app: App;
 	settings: DigitalGardenSettings;
+	siteUpdateTracker: SiteUpdateTracker | null;
 }
 
 export class PublicationCenterView extends ItemView {
@@ -35,7 +37,30 @@ export class PublicationCenterView extends ItemView {
 	}
 
 	async onOpen(): Promise<void> {
+		this.remountComponent();
+
+		// Refresh quietly whenever this view becomes the active leaf, so it
+		// reflects edits made while it was in the background.
+		this.registerEvent(
+			this.app.workspace.on("active-leaf-change", (leaf) => {
+				if (leaf === this.leaf) this.maybeRefresh();
+			}),
+		);
+	}
+
+	/**
+	 * (Re)mount the Svelte component from current plugin state. Called on
+	 * open and again when settings change something the view captures as
+	 * props (e.g. the publish platform's site-update tracker).
+	 */
+	remountComponent(): void {
 		const { app, settings } = this.plugin;
+
+		if (this.component) {
+			unmount(this.component);
+			this.component = undefined;
+			this.refreshApi = undefined;
+		}
 
 		const siteManager = new DigitalGardenSiteManager(
 			app.metadataCache,
@@ -55,20 +80,14 @@ export class PublicationCenterView extends ItemView {
 				siteManager,
 				publisher,
 				statusManager,
+				// Only set for gardens hosted on Forestry.md.
+				siteUpdateTracker: this.plugin.siteUpdateTracker,
 				openFile: (path: string) => this.openFile(path),
 				registerApi: (api: { maybeRefresh: () => void }) => {
 					this.refreshApi = api;
 				},
 			},
 		});
-
-		// Refresh quietly whenever this view becomes the active leaf, so it
-		// reflects edits made while it was in the background.
-		this.registerEvent(
-			this.app.workspace.on("active-leaf-change", (leaf) => {
-				if (leaf === this.leaf) this.maybeRefresh();
-			}),
-		);
 	}
 
 	async onClose(): Promise<void> {

--- a/src/views/PublicationCenterView/RecentBuilds.svelte
+++ b/src/views/PublicationCenterView/RecentBuilds.svelte
@@ -1,0 +1,278 @@
+<!-- src/views/PublicationCenterView/RecentBuilds.svelte -->
+<script lang="ts">
+	import { onMount } from "svelte";
+	import type { SiteUpdateTracker } from "../../forestry/SiteUpdateTracker";
+	import type { IDeployInfo } from "../../forestry/DeployInfo";
+
+	export let tracker: SiteUpdateTracker;
+
+	// All polling, notices, and state live in the tracker (shared with the
+	// status bar); this component only renders its store.
+	const updates = tracker.store;
+
+	let expanded = false;
+	let seenFailureCount: number | null = null;
+
+	// Auto-expand the list when a tracked update fails while the view is open.
+	$: {
+		if (seenFailureCount === null) {
+			seenFailureCount = $updates.failureCount;
+		} else if ($updates.failureCount > seenFailureCount) {
+			seenFailureCount = $updates.failureCount;
+			expanded = true;
+		}
+	}
+
+	$: builds = $updates.builds;
+	$: latest = builds[0] ?? null;
+	$: awaitingNewBuild = $updates.awaitingNewBuild;
+	$: limits = $updates.limits;
+
+	function statusKind(build: IDeployInfo): string {
+		if (build.status === "completed") return "success";
+
+		if (build.status === "failed") return "failure";
+
+		if (build.status === "cancelled") return "skipped";
+
+		return "running";
+	}
+
+	function statusLabel(build: IDeployInfo): string {
+		switch (build.status) {
+			case "completed":
+				return "Live";
+			case "failed":
+				return "Publish failed";
+			case "cancelled":
+				return "Replaced";
+			case "inprogress":
+				return "Publishing…";
+			default:
+				return "Queued";
+		}
+	}
+
+	function timeAgo(iso: string): string {
+		const seconds = Math.max(
+			0,
+			Math.floor((Date.now() - new Date(iso).getTime()) / 1000),
+		);
+
+		if (seconds < 60) return "just now";
+
+		if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+
+		if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+
+		return `${Math.floor(seconds / 86400)}d ago`;
+	}
+
+	function formatDuration(seconds: number): string {
+		if (seconds < 60) return `${seconds}s`;
+
+		return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+	}
+
+	// Re-render relative timestamps every 30s while visible.
+	let now = Date.now();
+
+	onMount(() => {
+		tracker.refresh();
+		const clock = setInterval(() => (now = Date.now()), 30000);
+
+		return () => clearInterval(clock);
+	});
+</script>
+
+{#if $updates.loaded && !$updates.loadFailed && (latest || awaitingNewBuild)}
+	<div class="dg-builds">
+		<button
+			class="dg-builds-header"
+			on:click={() => (expanded = !expanded)}
+			aria-expanded={expanded}
+		>
+			<span class="dg-builds-title">Publish status</span>
+			{#if awaitingNewBuild}
+				<span class="dg-builds-dot running"></span>
+				<span class="dg-builds-summary">Queued…</span>
+			{:else if latest}
+				{#key now}
+					<span class="dg-builds-dot {statusKind(latest)}"></span>
+					<span class="dg-builds-summary">
+						{statusLabel(latest)} · {timeAgo(latest.createdAt)}
+					</span>
+				{/key}
+			{/if}
+			<span class="dg-builds-chevron">{expanded ? "▾" : "▸"}</span>
+		</button>
+
+		{#if expanded}
+			<div class="dg-builds-list">
+				{#if awaitingNewBuild}
+					<div class="dg-builds-row">
+						<span class="dg-builds-dot running"></span>
+						<span>Waiting for publish to start…</span>
+					</div>
+				{/if}
+				{#key now}
+					{#each builds as build (build.runId)}
+						<div class="dg-builds-row">
+							<span class="dg-builds-dot {statusKind(build)}"
+							></span>
+							<span class="dg-builds-status"
+								>{statusLabel(build)}</span
+							>
+							<span class="dg-builds-meta">
+								{timeAgo(build.createdAt)}
+								{#if build.durationSeconds != null}
+									· {formatDuration(build.durationSeconds)}
+								{/if}
+								{#if build.branch && build.branch !== "main"}
+									· {build.branch}
+								{/if}
+							</span>
+						</div>
+						{#if build.status === "failed" && build.friendlyError}
+							<div class="dg-builds-error">
+								<div>{build.friendlyError.message}</div>
+								{#if build.friendlyError.hint}
+									<div class="dg-builds-error-hint">
+										{build.friendlyError.hint}
+									</div>
+								{/if}
+								{#if build.friendlyError.affectedNotes?.length}
+									<ul class="dg-builds-error-notes">
+										{#each build.friendlyError.affectedNotes as note}
+											<li>{note}</li>
+										{/each}
+									</ul>
+								{/if}
+							</div>
+						{/if}
+					{/each}
+				{/key}
+				{#if limits}
+					<div class="dg-builds-limits">
+						{limits.builds.monthlyRemaining} of {limits.builds
+							.monthlyLimit} publishes left this month
+					</div>
+				{/if}
+			</div>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.dg-builds {
+		border-top: 1px solid var(--background-modifier-border);
+	}
+
+	.dg-builds-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		width: 100%;
+		padding: 6px 12px;
+		background: none;
+		border: none;
+		box-shadow: none;
+		cursor: pointer;
+		font-size: 0.85rem;
+		text-align: left;
+	}
+
+	.dg-builds-title {
+		font-weight: 600;
+	}
+
+	.dg-builds-summary {
+		color: var(--text-muted);
+	}
+
+	.dg-builds-chevron {
+		margin-left: auto;
+		color: var(--text-muted);
+	}
+
+	.dg-builds-dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+
+	.dg-builds-dot.success {
+		background: var(--color-green, #4caf50);
+	}
+
+	.dg-builds-dot.failure {
+		background: var(--color-red, #f44336);
+	}
+
+	.dg-builds-dot.skipped {
+		background: var(--text-faint, #999);
+	}
+
+	.dg-builds-dot.running {
+		background: var(--color-yellow, #ffc107);
+		animation: dg-builds-pulse 1.5s ease-in-out infinite;
+	}
+
+	@keyframes dg-builds-pulse {
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.3;
+		}
+	}
+
+	.dg-builds-list {
+		max-height: 220px;
+		overflow-y: auto;
+		padding: 0 12px 8px;
+	}
+
+	.dg-builds-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 3px 0;
+		font-size: 0.85rem;
+	}
+
+	.dg-builds-status {
+		min-width: 90px;
+	}
+
+	.dg-builds-meta {
+		color: var(--text-muted);
+	}
+
+	.dg-builds-error {
+		margin: 2px 0 6px 16px;
+		padding: 6px 8px;
+		border-left: 2px solid var(--color-red, #f44336);
+		background: var(--background-secondary);
+		font-size: 0.8rem;
+	}
+
+	.dg-builds-error-hint {
+		color: var(--text-muted);
+		margin-top: 2px;
+	}
+
+	.dg-builds-error-notes {
+		margin: 4px 0 0;
+		padding-left: 16px;
+		color: var(--text-muted);
+	}
+
+	.dg-builds-limits {
+		margin-top: 6px;
+		color: var(--text-faint);
+		font-size: 0.75rem;
+	}
+</style>

--- a/styles.css
+++ b/styles.css
@@ -577,3 +577,26 @@ h4 {
 	width: 16px;
 	height: 16px;
 }
+
+/* Forestry site-update status bar item */
+.dg-site-status {
+	cursor: pointer;
+}
+
+.dg-site-status.dg-site-status-updating {
+	animation: dg-site-status-pulse 1.5s ease-in-out infinite;
+}
+
+.dg-site-status.dg-site-status-failed {
+	color: var(--text-error);
+}
+
+@keyframes dg-site-status-pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.4;
+	}
+}


### PR DESCRIPTION
## What

For Forestry.md gardens, the plugin now surfaces what happens *after* notes are pushed — whether the site actually went live.

- **Publish status strip** in the Publication Center: last 10 site updates with status, relative time, duration, and friendly build errors (message/hint/affected notes), plus the monthly publish quota. Live-tracks a fresh publish through queued → publishing → live/failed, handling the webhook-debounce gap and superseded (replaced) updates.
- **Plugin-wide `SiteUpdateTracker` + persistent status bar item** (🌱 idle / 🌱 Publishing… / 🌱 Live / 🌱 Publish failed): every publish path — Publish Active Note, Quick Publish, Publish All, Publication Center — reports the real outcome with notices, even when the Publication Center is closed. Clicking the item opens the Publication Center.
- **Real upload progress** during batch publishes: per-blob progress (notes and images) plus a commit step, instead of a bar that jumped 0 → 100 in one go.
- **Settings-reactive**: tracker, status bar, and open Publication Center views are created/torn down on settings save, so switching publish platform or changing the API key takes effect immediately without a reload.

## Server dependency

Uses the new token-auth `GET /app/Pages/deploys` endpoint (DigitalForestApi `ae51c99`, deployed). The strip hides itself gracefully when the endpoint is unavailable or the platform is self-hosted GitHub.

## Testing

- `npm run typecheck`, `npm test` (254 passing), `npm run build` all green
- Manually exercised in the dev vault: strip rendering, post-publish live tracking, status bar phases, platform switching tearing the UI down

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwa8krJHt1TXWxHWDueBTV