### PR TITLE
feat(settings): Make template update notifications opt-in

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "Dev shell for obsidian-digital-garden (Obsidian plugin, esbuild + npm)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          # CI (.github/workflows/actions.yml) pins node via .nvmrc (20.6.0) and
+          # uses npm. Node 20 hit upstream EOL and was dropped from nixpkgs, so
+          # this shell uses nodejs_22 (next LTS) instead; it bundles npm. bun is
+          # included too since the repo also ships a bun.lockb.
+          packages = [
+            pkgs.nodejs_22
+            pkgs.bun
+          ];
+
+          shellHook = ''
+            echo "obsidian-digital-garden devshell: $(node --version) / npm $(npm --version) / $(bun --version)"
+          '';
+        };
+      });
+}

--- a/main.ts
+++ b/main.ts
@@ -285,6 +285,10 @@ export default class DigitalGarden extends Plugin {
 			return;
 		}
 
+		if (this.settings.disableTemplateUpdateNotice) {
+			return;
+		}
+
 		try {
 			const siteManager = new DigitalGardenSiteManager(
 				this.app.metadataCache,

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -91,6 +91,9 @@ export default interface DigitalGardenSettings {
 	/** When true, the "switch to Forestry.md" nudge in the self-hosted setup is hidden. */
 	hideForestryUpgradeNotice?: boolean;
 
+	/** When true, the automatic startup check for site template updates (and its Notice) is skipped. Manually checking/updating in settings still works. */
+	disableTemplateUpdateNotice?: boolean;
+
 	ENABLE_DEVELOPER_TOOLS?: boolean;
 	devPluginPath?: string;
 	logLevel?: ILogLevel;

--- a/src/views/SettingsView/SettingView.ts
+++ b/src/views/SettingsView/SettingView.ts
@@ -2332,6 +2332,20 @@ export default class SettingView {
 			.createEl("h3", { text: "Update site template" })
 			.prepend(getIcon("sync") ?? "");
 
+		new Setting(target)
+			.setName("Check for template updates on startup")
+			.setDesc(
+				"Show a notice on launch when a new site template version is available. Disable this if your template has diverged from the default and won't ever match. You can still check for updates manually below.",
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(!this.settings.disableTemplateUpdateNotice)
+					.onChange(async (value) => {
+						this.settings.disableTemplateUpdateNotice = !value;
+						await this.saveSettings();
+					});
+			});
+
 		// Show loading indicator while checking for updates
 		const loadingContainer = target.createDiv({
 			cls: "dg-update-loading",


### PR DESCRIPTION
Hi! 

Really loving this plugin. It's been a great help. Figured that for people like myself who've more or less decided to deviate from the upstream template, having the option to disable these notifications with a toggle in the settings would be useful.

I also added a flake devshell for those who use nix. Gives them access to the tools required for this project, like npm. If you'd rather not have it, just say the word, and I'll drop it.

Thanks for building this!!